### PR TITLE
Change variable names for alphabetical order

### DIFF
--- a/aws-vpc.tf
+++ b/aws-vpc.tf
@@ -1,7 +1,7 @@
 /* Setup our aws provider */
 provider "aws" {
-  access_key  = "${var.access_key}"
-  secret_key  = "${var.secret_key}"
+  access_key  = "${var.aws_access_key}"
+  secret_key  = "${var.aws_secret_key}"
   region      = "${var.region}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,8 @@
-variable "access_key" { 
+variable "aws_access_key" { 
   description = "AWS access key"
 }
 
-variable "secret_key" { 
+variable "aws_secret_key" { 
   description = "AWS secert access key"
 }
 


### PR DESCRIPTION
When running `terraform`, variables are prompted for on the command line. The AWS secret key and access key need to be entered, but for the rest, for now, the default can be accepted. This change puts the secret key and access key up first so you can just enter them and then press return through the rest of them, for ease of use.
