### PR TITLE
Use private subnets

### DIFF
--- a/app-servers.tf
+++ b/app-servers.tf
@@ -40,7 +40,7 @@ resource "aws_autoscaling_group" "router" {
 /* Router Load balancer */
 resource "aws_elb" "router" {
   name = "tsuru-router-elb"
-  subnets = ["${aws_subnet.public.id}"]
+  subnets = ["${aws_subnet.private1.id}", "${aws_subnet.private2.id}"]
   security_groups = ["${aws_security_group.default.id}", "${aws_security_group.web.id}"]
   listener {
     instance_port = 80


### PR DESCRIPTION
Match the subnets that we are using when creating the Autoscaling Group.
