### PR TITLE
Add wildcard DNS record for applications

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -7,6 +7,15 @@ resource "aws_route53_record" "router" {
   records = ["${aws_elb.router.dns_name}"]
 }
 
+/* Wildcard CNAME record */
+resource "aws_route53_record" "wildcard" {
+  zone_id = "${aws_route53_zone.public.zone_id}"
+  name = "*.hipache.tsuru.paas.alphagov.co.uk"
+  type = "CNAME"
+  ttl = "60"
+  records = ["${aws_route53_record.router.name}"]
+}
+
 /* Public Hosted Zone */
 resource "aws_route53_zone" "public" {
    name = "tsuru.paas.alphagov.co.uk"


### PR DESCRIPTION
By adding this record, we don't need to worry about creating each application's DNS record manually.
Instead, all the subdomains will be resolved to the main router DNS name.
