### PR TITLE
Added suuport for a docker-registry VM/LB/Autoscaling Group

### DIFF
--- a/cloud-config/docker-registry.yml
+++ b/cloud-config/docker-registry.yml
@@ -1,0 +1,10 @@
+#cloud-config
+# Cloud config for docker-registry servers
+
+runcmd:
+  # Install Tsuru repos
+  - sudo apt-add-repository ppa:tsuru/ppa -y
+  - sudo apt-get update
+  - sudo apt-get install python-software-properties -y
+
+output: {all: '| tee -a /var/log/cloud-init-output.log'}

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -51,3 +51,12 @@ resource "aws_route53_record" "nat" {
   ttl = "60"
   records = ["${aws_instance.nat.public_ip}"]
 }
+/* Docker-registry A record */
+resource "aws_route53_record" "docker-registry" {
+  zone_id = "ZAO40KKT7J2PB"
+  name = "docker-registry.tsuru.paas.alphagov.co.uk"
+  type = "A"
+  ttl = "60"
+  records = ["${aws_instance.docker-registry.private_ip}"]
+}
+

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -51,12 +51,14 @@ resource "aws_route53_record" "nat" {
   ttl = "60"
   records = ["${aws_instance.nat.public_ip}"]
 }
-/* Docker-registry A record */
-resource "aws_route53_record" "docker-registry" {
+
+
+/* Docker-registry internal CNAME record */
+resource "aws_route53_record" "api-internal" {
   zone_id = "ZAO40KKT7J2PB"
   name = "docker-registry.tsuru.paas.alphagov.co.uk"
-  type = "A"
+  type = "CNAME"
   ttl = "60"
-  records = ["${aws_instance.docker-registry.private_ip}"]
+  records = ["${aws_instance.docker-registry.dns_name}"]
 }
 

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -51,14 +51,12 @@ resource "aws_route53_record" "nat" {
   ttl = "60"
   records = ["${aws_instance.nat.public_ip}"]
 }
-
-
-/* Docker-registry internal CNAME record */
+/* Docker-registry A record */
 resource "aws_route53_record" "docker-registry" {
   zone_id = "ZAO40KKT7J2PB"
   name = "docker-registry.tsuru.paas.alphagov.co.uk"
-  type = "CNAME"
+  type = "A"
   ttl = "60"
-  records = ["${aws_instance.docker-registry.dns_name}"]
+  records = ["${aws_instance.docker-registry.private_ip}"]
 }
 

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -54,7 +54,7 @@ resource "aws_route53_record" "nat" {
 
 
 /* Docker-registry internal CNAME record */
-resource "aws_route53_record" "api-internal" {
+resource "aws_route53_record" "docker-registry" {
   zone_id = "ZAO40KKT7J2PB"
   name = "docker-registry.tsuru.paas.alphagov.co.uk"
   type = "CNAME"

--- a/docker-registry.tf
+++ b/docker-registry.tf
@@ -33,12 +33,13 @@ resource "aws_autoscaling_group" "docker-registry" {
 /* Docker-registry internal Load balancer */
 resource "aws_elb" "docker-registry" {
   name = "docker-registry"
-  subnets = ["${aws_subnet.public1.id}", "${aws_subnet.public2.id}"]
-  security_groups = ["${aws_security_group.default.id}", "${aws_security_group.web.id}"]
+  subnets = ["${aws_subnet.private1.id}", "${aws_subnet.private2.id}"]
+  security_groups = ["${aws_security_group.default.id}"]
+  internal = true
   listener {
-    instance_port = 5000
+    instance_port = 6000
     instance_protocol = "tcp"
-    lb_port = 5000
+    lb_port = 6000
     lb_protocol = "tcp"
   }
 }

--- a/docker-registry.tf
+++ b/docker-registry.tf
@@ -1,0 +1,44 @@
+/* Docker-registry Launch configuration */
+resource "aws_launch_configuration" "docker-registry" {
+  name = "docker_registry_config"
+  image_id = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.medium"
+  security_groups = ["${aws_security_group.default.id}"]
+  key_name = "${aws_key_pair.deployer.key_name}"
+  user_data = "${file(\"cloud-config/docker-registry.yml\")}"
+}
+
+/* Docker-registry Autoscaling Group */
+resource "aws_autoscaling_group" "docker-registry" {
+  availability_zones = ["${var.region}a", "${var.region}b"]
+  vpc_zone_identifier = ["${aws_subnet.private1.id}", "${aws_subnet.private2.id}"]
+  name = "tsuru-docker-registry"
+  max_size = 1
+  min_size = 1
+  health_check_grace_period = 300
+  health_check_type = "EC2"
+  desired_capacity = 1
+  force_delete = true
+  launch_configuration = "${aws_launch_configuration.docker-registry.name}"
+  load_balancers = ["${aws_elb.docker-registry.name}"]
+  /* To be added after v0.4.0
+  tag = {
+    key = "Name"
+    value = "tsuru-docker-registry"
+    propagate_at_launch = true
+  }
+  */
+}
+
+/* Docker-registry internal Load balancer */
+resource "aws_elb" "docker-registry" {
+  name = "docker-registry"
+  subnets = ["${aws_subnet.public1.id}", "${aws_subnet.public2.id}"]
+  security_groups = ["${aws_security_group.default.id}", "${aws_security_group.web.id}"]
+  listener {
+    instance_port = 5000
+    instance_protocol = "tcp"
+    lb_port = 5000
+    lb_protocol = "tcp"
+  }
+}

--- a/docker-registry.tf
+++ b/docker-registry.tf
@@ -1,45 +1,13 @@
-/* Docker-registry Launch configuration */
-resource "aws_launch_configuration" "docker-registry" {
-  name = "docker_registry_config"
-  image_id = "${lookup(var.amis, var.region)}"
+/* Docker Registry */
+resource "aws_instance" "docker-registry" {
+  count = 1
+  ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
+  subnet_id = "${aws_subnet.private1.id}"
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${aws_key_pair.deployer.key_name}"
   user_data = "${file(\"cloud-config/docker-registry.yml\")}"
-}
-
-/* Docker-registry Autoscaling Group */
-resource "aws_autoscaling_group" "docker-registry" {
-  availability_zones = ["${var.region}a", "${var.region}b"]
-  vpc_zone_identifier = ["${aws_subnet.private1.id}", "${aws_subnet.private2.id}"]
-  name = "tsuru-docker-registry"
-  max_size = 1
-  min_size = 1
-  health_check_grace_period = 300
-  health_check_type = "EC2"
-  desired_capacity = 1
-  force_delete = true
-  launch_configuration = "${aws_launch_configuration.docker-registry.name}"
-  load_balancers = ["${aws_elb.docker-registry.name}"]
-  /* To be added after v0.4.0
-  tag = {
-    key = "Name"
-    value = "tsuru-docker-registry"
-    propagate_at_launch = true
-  }
-  */
-}
-
-/* Docker-registry internal Load balancer */
-resource "aws_elb" "docker-registry" {
-  name = "docker-registry"
-  subnets = ["${aws_subnet.private1.id}", "${aws_subnet.private2.id}"]
-  security_groups = ["${aws_security_group.default.id}"]
-  internal = true
-  listener {
-    instance_port = 6000
-    instance_protocol = "tcp"
-    lb_port = 6000
-    lb_protocol = "tcp"
+  tags = {
+    Name = "docker-registry-${count.index}"
   }
 }


### PR DESCRIPTION
Two additional files added to the terraform config to provision a LaunchConfiguration, AutoScaling Group and ELB for a resilient docker-registry instance.

The AutoScaling group ensures that we will always have exactly 1 docker-registry server running.
The LoadBalancer is required for a consistent IP address (and later for additional health checks)
