### PR TITLE
Implement https on the api

### DIFF
--- a/app-servers.tf
+++ b/app-servers.tf
@@ -38,6 +38,13 @@ resource "aws_elb" "api-ext" {
     lb_port = 8080
     lb_protocol = "http"
   }
+  listener {
+    instance_port = 8080
+    instance_protocol = "http"
+    lb_port = 443
+    lb_protocol = "https"
+    ssl_certificate_id = "${var.api_ssl_certificate_id}"
+  }
 }
 
 /* API internal Load balancer */

--- a/variables.tf
+++ b/variables.tf
@@ -52,3 +52,8 @@ variable "nat_ami" {
     eu-central-1 = "ami-a8221fb5"
   }
 }
+
+variable "api_ssl_certificate_id" {
+  description = "SSL Certificate for Tsuru API"
+  default = "arn:aws:iam::988997429095:server-certificate/wildcard_tsuru_paas_alphagov" 
+}


### PR DESCRIPTION
[Implement HTTPS on the Tsuru API](https://www.pivotaltracker.com/story/show/91386462)

Adding an SSL certificate to the Tsuru API elastic load balancer to secure traffic from the tsuru-client over the internet.
