### PR TITLE
Add Autoscaling group tags

### DIFF
--- a/app-servers.tf
+++ b/app-servers.tf
@@ -85,13 +85,11 @@ resource "aws_autoscaling_group" "router" {
   force_delete = true
   launch_configuration = "${aws_launch_configuration.router.name}"
   load_balancers = ["${aws_elb.router.name}"]
-  /* To be added after v0.4.0
   tag = {
     key = "Name"
     value = "tsuru-app-router"
     propagate_at_launch = true
   }
-  */
 }
 
 /* Router Load balancer */


### PR DESCRIPTION
Now that Terraform >= 0.4.0 is more widely available (brew), we can implement this change. This will make sure that Autoscaling instances get tagged properly when they're launched.
