### PR TITLE
Split out docker on a separate instance

### DIFF
--- a/app-servers.tf
+++ b/app-servers.tf
@@ -1,6 +1,6 @@
-/* API and Docker servers */
+/* API server */
 resource "aws_instance" "tsuru-app" {
-  count = 2
+  count = 1
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.private1.id}"
@@ -9,6 +9,23 @@ resource "aws_instance" "tsuru-app" {
   user_data = "${file(\"cloud-config/app.yml\")}"
   tags = {
     Name = "tsuru-app-${count.index}"
+  }
+}
+
+/* Docker server */
+resource "aws_instance" "tsuru-docker" {
+  ami = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.medium"
+  subnet_id = "${aws_subnet.private1.id}"
+  security_groups = ["${aws_security_group.default.id}"]
+  key_name = "${aws_key_pair.deployer.key_name}"
+  user_data = "${file(\"cloud-config/app.yml\")}"
+  tags = {
+    Name = "tsuru-app-docker"
+  }
+  root_block_device {
+   volume_type = "gp2"
+   volume_size = 100
   }
 }
 


### PR DESCRIPTION
We ran out of disk space on the docker registry instance:

```
error in docker node "http://10.128.1.207:4243": Error saving transaction meta data: Error writing metadata to /var/lib/docker/devicemapper/metadata/.tmp496725100: write /var/lib/docker/devicemapper/metadata/.tmp496725100: no space left on device
```

Hence we need to have a bigger size disk for the docker registry instance.
This requires to create the EBS volume separately in order to specify the size.
