### PR TITLE
Add sslproxy userdata

### DIFF
--- a/cloud-config/sslproxy.yml
+++ b/cloud-config/sslproxy.yml
@@ -1,0 +1,8 @@
+# Cloud config for nginx SSL proxy
+
+runcmd:
+  # Install Tsuru repos
+  - sudo apt-get update 
+  - sudo apt-get install nginx -y
+
+output: {all: '| tee -a /var/log/cloud-init-output.log'}


### PR DESCRIPTION
Somehow we forgot to include this in the previous commit, so here it is.
This file is being used in the SSLProxy Autoscaling Group launch configuration.
