### PR TITLE
Split out Docker node

### DIFF
--- a/app-servers.tf
+++ b/app-servers.tf
@@ -1,6 +1,6 @@
-/* API and Docker servers */
+/* API server */
 resource "aws_instance" "tsuru-app" {
-  count = 2
+  count = 1
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.private1.id}"
@@ -9,6 +9,19 @@ resource "aws_instance" "tsuru-app" {
   user_data = "${file(\"cloud-config/app.yml\")}"
   tags = {
     Name = "tsuru-app-${count.index}"
+  }
+}
+
+/* Docker server */
+resource "aws_instance" "tsuru-docker" {
+  ami = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.medium"
+  subnet_id = "${aws_subnet.private1.id}"
+  security_groups = ["${aws_security_group.default.id}"]
+  key_name = "${aws_key_pair.deployer.key_name}"
+  user_data = "${file(\"cloud-config/app.yml\")}"
+  tags = {
+    Name = "tsuru-app-docker"
   }
 }
 


### PR DESCRIPTION
This is the first step towards a complete separation and cleanup of all the Tsuru components.
It makes sense to separate these instances so we can customise them according to our needs.
