### PR TITLE
Increase Docker registry disk size

### DIFF
--- a/aws/docker-registry.tf
+++ b/aws/docker-registry.tf
@@ -10,4 +10,8 @@ resource "aws_instance" "docker-registry" {
   tags = {
     Name = "docker-registry-${count.index}"
   }
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 100
+  }
 }


### PR DESCRIPTION
We were getting the following error on the registry otherwise:

```
IOError: [Errno 28] No space left on device
28/Apr/2015:09:57:38 +0000 ERROR: Exception on /v1/images/5db4ca6f82991daec64345148b27dc6c8a55e668791353544b50f26c4285a290/layer [PUT]
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/toolkit.py", line 280, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/toolkit.py", line 37, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/images.py", line 226, in put_image_layer
    save_checksums(image_id, csums)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/images.py", line 316, in save_checksums
    store.put_content(checksum_path, json.dumps(checksums))
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/drivers/file.py", line 63, in put_content
    f.write(content)
IOError: [Errno 28] No space left on device
```
