### PR TITLE
[#92502564] GCE: Add NAT+Gandalf public IPs to web firewall

### DIFF
--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -48,7 +48,11 @@ resource "google_compute_firewall" "web" {
   description = "Security group for web that allows web traffic from internet"
   network = "${google_compute_network.network1.name}"
 
-  source_ranges = [ "80.194.77.90/32", "80.194.77.100/32" ]
+  source_ranges = [
+    "80.194.77.90/32", "80.194.77.100/32",
+    "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}",
+    "${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}",
+  ]
   target_tags = [ "web" ]
 
   allow {


### PR DESCRIPTION
It seems that `source_tags` and `target_tags` don't have an effect when
traffic routes via public IPs. The result of this was:
- Gandalf was unable to make a callback to the API when deploying an
  application
- The application container was unable to make a callback to the API when an
  application was started during deployment

So we've had to add machines that have ephemeral addresses to the
`source_ranges` list in order to make this work.
