### PR TITLE
Centralise and restrict office IPs

### DIFF
--- a/aws/globals.tf
+++ b/aws/globals.tf
@@ -1,0 +1,1 @@
+../globals.tf

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "nat" {
     from_port = 22
     to_port   = 22
     protocol  = "tcp"
-    cidr_blocks = ["80.194.77.0/24"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
  
   tags { 
@@ -44,7 +44,7 @@ resource "aws_security_group" "gandalf" {
     from_port = 22
     to_port   = 22
     protocol  = "tcp"
-    cidr_blocks = ["80.194.77.0/24"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
 
   tags {
@@ -62,21 +62,21 @@ resource "aws_security_group" "web" {
     from_port = 80
     to_port   = 80
     protocol  = "tcp"
-    cidr_blocks = ["80.194.77.0/24"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
 
   ingress {
     from_port = 8080
     to_port   = 8080
     protocol  = "tcp"
-    cidr_blocks = ["80.194.77.0/24"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
 
   ingress {
     from_port = 443
     to_port   = 443
     protocol  = "tcp"
-    cidr_blocks = ["80.194.77.0/24"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
  
   tags { 
@@ -127,27 +127,14 @@ resource "aws_security_group" "sslproxy" {
     from_port = 80
     to_port   = 80
     protocol  = "tcp"
-    cidr_blocks = ["80.194.77.90/32"]
-  }
-  ingress {
-    from_port = 80
-    to_port   = 80
-    protocol  = "tcp"
-    cidr_blocks = ["80.194.77.100/32"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
 
   ingress {
     from_port = 443
     to_port   = 443
     protocol  = "tcp"
-    cidr_blocks = ["80.194.77.90/32"]
-  }
-
-  ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-    cidr_blocks = ["80.194.77.100/32"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
   
   tags { 

--- a/gce/globals.tf
+++ b/gce/globals.tf
@@ -1,0 +1,1 @@
+../globals.tf

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -18,7 +18,7 @@ resource "google_compute_firewall" "nat" {
   description = "Security group for nat instances that allows SSH and VPN traffic from internet"
   network = "${google_compute_network.network1.name}"
 
-  source_ranges = [ "80.194.77.90/32", "80.194.77.100/32" ]
+  source_ranges = ["${split(",", var.office_cidrs)}"]
   target_tags = [ "nat" ]
 
   allow {
@@ -33,7 +33,7 @@ resource "google_compute_firewall" "gandalf" {
   description = "Security group for Gandalf instance that allows SSH access from internet"
   network = "${google_compute_network.network1.name}"
 
-  source_ranges = [ "80.194.77.90/32", "80.194.77.100/32" ]
+  source_ranges = ["${split(",", var.office_cidrs)}"]
   target_tags = [ "gandalf" ]
 
   allow {
@@ -49,7 +49,7 @@ resource "google_compute_firewall" "web" {
   network = "${google_compute_network.network1.name}"
 
   source_ranges = [
-    "80.194.77.90/32", "80.194.77.100/32",
+    "${split(",", var.office_cidrs)}",
     "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}",
     "${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}",
   ]

--- a/globals.tf
+++ b/globals.tf
@@ -1,0 +1,4 @@
+variable "office_cidrs" {
+  description = "CSV of CIDR addresses for our office which will be trusted"
+  default     = "80.194.77.90/32,80.194.77.100/32"
+}


### PR DESCRIPTION
#### gce: Centralise office IPs

So that we're not repeating these in multiple places. I'm symlinking in the
file from the root directory because I intend to reuse it for AWS.

This is a noop when running `terraform plan`.
#### aws: Centralise and restrict office IPs

Use the variable which is shared by GCE for the list of office IPs. This
also restricts it to the two egress IPs that we own, rather than the entire
range which is used by other customers of our provider.

Some rules have been de-duped because we can pass a list of addresses.

---

I haven't deployed the change to AWS. Will after merge.
