### PR TITLE
Handle Autoscaling Group Launch configuration updates

### DIFF
--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -1,11 +1,13 @@
 /* API servers Launch configuration */
 resource "aws_launch_configuration" "api" {
-  name = "tsuru_api_config"
   image_id = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${aws_key_pair.deployer.key_name}"
   user_data = "${file(\"cloud-config/app.yml\")}"
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 /* API servers Autoscaling Group */

--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -1,11 +1,13 @@
 /* Router Launch configuration */
 resource "aws_launch_configuration" "router" {
-  name = "tsuru_router_config"
   image_id = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${aws_key_pair.deployer.key_name}"
   user_data = "${file(\"cloud-config/router.yml\")}"
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 /* Router Autoscaling Group */

--- a/aws/ssl-proxies.tf
+++ b/aws/ssl-proxies.tf
@@ -1,11 +1,13 @@
 /* SSL proxy Launch configuration */
 resource "aws_launch_configuration" "tsuru-sslproxy" {
-  name = "tsuru_sslproxy_config"
   image_id = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
   security_groups = ["${aws_security_group.default.id}","${aws_security_group.sslproxy.id}"]
   key_name = "${aws_key_pair.deployer.key_name}"
   user_data = "${file(\"cloud-config/sslproxy.yml\")}"
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 /* SSL proxy Autoscaling Group */


### PR DESCRIPTION
Up until now we were not able to update a launch configuration (i.e.: AMI, user-data, instance type)
due to this bug: https://github.com/hashicorp/terraform/issues/532
By removing the launch configuration name, we let Terraform generate a random one for us.
This will help when updating the launch configurations (this involves create a new resource and delete the old one).
