### PR TITLE
[#93688938] Dynamic named GCE environments

### DIFF
--- a/gce/api-servers.tf
+++ b/gce/api-servers.tf
@@ -1,7 +1,7 @@
 /* API server */
 resource "google_compute_instance" "api" {
   count = 2
-  name = "tsuru-api-${var.env}-${count.index}"
+  name = "${var.env}-tsuru-api-${count.index}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -21,23 +21,23 @@ resource "google_compute_instance" "api" {
 
 /* API load balancer */
 resource "google_compute_http_health_check" "api" {
-  name = "tsuru-api-${var.env}"
+  name = "${var.env}-tsuru-api"
   port = 8080
   request_path = "/info"
   check_interval_sec = 1
   timeout_sec = 1
 }
 resource "google_compute_target_pool" "api" {
-  name = "tsuru-api-lb-${var.env}"
+  name = "${var.env}-tsuru-api-lb"
   instances = [ "${google_compute_instance.api.*.self_link}" ]
   health_checks = [ "${google_compute_http_health_check.api.name}" ]
 }
 resource "google_compute_forwarding_rule" "api" {
-  name = "tsuru-api-lb-${var.env}"
+  name = "${var.env}-tsuru-api-lb"
   target = "${google_compute_target_pool.api.self_link}"
   port_range = 8080
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} api-${var.env}.${var.dns_zone_name} 60 A ${google_compute_forwarding_rule.api.ip_address}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} ${var.env}-api.${var.dns_zone_name} 60 A ${google_compute_forwarding_rule.api.ip_address}"
   }
 }

--- a/gce/docker-registry.tf
+++ b/gce/docker-registry.tf
@@ -1,6 +1,6 @@
 /* Docker Registry */
 resource "google_compute_instance" "docker-registry" {
-  name = "docker-registry-${var.env}"
+  name = "${var.env}-docker-registry"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -19,6 +19,6 @@ resource "google_compute_instance" "docker-registry" {
   tags = [ "private" ]
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} docker-registry-${var.env}.${var.dns_zone_name} 60 A ${google_compute_instance.docker-registry.network_interface.0.address}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} ${var.env}-docker-registry.${var.dns_zone_name} 60 A ${google_compute_instance.docker-registry.network_interface.0.address}"
   }
 }

--- a/gce/docker-registry.tf
+++ b/gce/docker-registry.tf
@@ -1,6 +1,6 @@
 /* Docker Registry */
 resource "google_compute_instance" "docker-registry" {
-  name = "docker-registry"
+  name = "docker-registry-${var.env}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -19,6 +19,6 @@ resource "google_compute_instance" "docker-registry" {
   tags = [ "private" ]
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_name} docker-registry.${var.dns_zone_name} 60 A ${google_compute_instance.docker-registry.network_interface.0.address}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} docker-registry-${var.env}.${var.dns_zone_name} 60 A ${google_compute_instance.docker-registry.network_interface.0.address}"
   }
 }

--- a/gce/docker-servers.tf
+++ b/gce/docker-servers.tf
@@ -1,6 +1,6 @@
 /* Docker server */
 resource "google_compute_instance" "tsuru-docker" {
-  name = "tsuru-app-docker"
+  name = "tsuru-app-docker-${var.env}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/docker-servers.tf
+++ b/gce/docker-servers.tf
@@ -1,6 +1,6 @@
 /* Docker server */
-resource "google_compute_instance" "tsuru-docker" {
-  name = "tsuru-app-docker-${var.env}"
+resource "google_compute_instance" "docker" {
+  name = "tsuru-docker-${var.env}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/docker-servers.tf
+++ b/gce/docker-servers.tf
@@ -1,6 +1,6 @@
 /* Docker server */
 resource "google_compute_instance" "docker" {
-  name = "tsuru-docker-${var.env}"
+  name = "${var.env}-tsuru-docker"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/gandalf.tf
+++ b/gce/gandalf.tf
@@ -1,6 +1,6 @@
 /* Gandalf server */
 resource "google_compute_instance" "gandalf" {
-  name = "tsuru-gandalf-${var.env}"
+  name = "${var.env}-tsuru-gandalf"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -19,6 +19,6 @@ resource "google_compute_instance" "gandalf" {
   tags = [ "public", "gandalf" ]
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} gandalf-${var.env}.${var.dns_zone_name} 60 A ${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} ${var.env}-gandalf.${var.dns_zone_name} 60 A ${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}"
   }
 }

--- a/gce/gandalf.tf
+++ b/gce/gandalf.tf
@@ -1,6 +1,6 @@
 /* Gandalf server */
 resource "google_compute_instance" "gandalf" {
-  name = "tsuru-app-gandalf-${var.env}"
+  name = "tsuru-gandalf-${var.env}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/gandalf.tf
+++ b/gce/gandalf.tf
@@ -1,6 +1,6 @@
 /* Gandalf server */
 resource "google_compute_instance" "gandalf" {
-  name = "tsuru-app-gandalf"
+  name = "tsuru-app-gandalf-${var.env}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -19,6 +19,6 @@ resource "google_compute_instance" "gandalf" {
   tags = [ "public", "gandalf" ]
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} gandalf.${var.dns_zone_name} 60 A ${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} gandalf-${var.env}.${var.dns_zone_name} 60 A ${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}"
   }
 }

--- a/gce/http-health-check.tf
+++ b/gce/http-health-check.tf
@@ -1,5 +1,5 @@
 resource "google_compute_http_health_check" "http-check" {
-  name = "http-check"
+  name = "http-check-${var.env}"
   request_path = "/"
   check_interval_sec = 1
   timeout_sec = 1

--- a/gce/http-health-check.tf
+++ b/gce/http-health-check.tf
@@ -1,5 +1,5 @@
 resource "google_compute_http_health_check" "http-check" {
-  name = "http-check-${var.env}"
+  name = "${var.env}-http-check"
   request_path = "/"
   check_interval_sec = 1
   timeout_sec = 1

--- a/gce/mongo-redis.tf
+++ b/gce/mongo-redis.tf
@@ -1,7 +1,6 @@
-/* Legacy API server, MongoDB and Redis DB server */
-resource "google_compute_instance" "tsuru-app" {
-  count = 1
-  name = "tsuru-app-${var.env}-${count.index}"
+/* MongoDB and Redis DB server */
+resource "google_compute_instance" "db" {
+  name = "tsuru-db-${var.env}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/mongo-redis.tf
+++ b/gce/mongo-redis.tf
@@ -1,7 +1,7 @@
 /* Legacy API server, MongoDB and Redis DB server */
 resource "google_compute_instance" "tsuru-app" {
   count = 1
-  name = "tsuru-app-${count.index}"
+  name = "tsuru-app-${var.env}-${count.index}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/mongo-redis.tf
+++ b/gce/mongo-redis.tf
@@ -1,6 +1,6 @@
 /* MongoDB and Redis DB server */
 resource "google_compute_instance" "db" {
-  name = "tsuru-db-${var.env}"
+  name = "${var.env}-tsuru-db"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/nat-server.tf
+++ b/gce/nat-server.tf
@@ -1,6 +1,6 @@
 /* Jumpbox Server Instance */
 resource "google_compute_instance" "nat" {
-  name = "tsuru-nat"
+  name = "tsuru-nat-${var.env}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -39,6 +39,6 @@ resource "google_compute_instance" "nat" {
   tags = [ "public", "nat" ]
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} nat.${var.dns_zone_name} 60 A ${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} nat-${var.env}.${var.dns_zone_name} 60 A ${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}"
   }
 }

--- a/gce/nat-server.tf
+++ b/gce/nat-server.tf
@@ -1,6 +1,6 @@
 /* Jumpbox Server Instance */
 resource "google_compute_instance" "nat" {
-  name = "tsuru-nat-${var.env}"
+  name = "${var.env}-tsuru-nat"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -39,6 +39,6 @@ resource "google_compute_instance" "nat" {
   tags = [ "public", "nat" ]
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} nat-${var.env}.${var.dns_zone_name} 60 A ${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} ${var.env}-nat.${var.dns_zone_name} 60 A ${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}"
   }
 }

--- a/gce/network-subnet.tf
+++ b/gce/network-subnet.tf
@@ -1,11 +1,11 @@
 /* Networks */
 resource "google_compute_network" "network1" {
-  name = "tsuru-network1-${var.env}"
+  name = "${var.env}-tsuru-network1"
   ipv4_range = "${var.network1_cidr}"
 }
 
 resource "google_compute_route" "private_default" {
-  name = "private-default-${var.env}"
+  name = "${var.env}-private-default"
   dest_range = "0.0.0.0/0"
   network = "${google_compute_network.network1.name}"
   next_hop_instance = "${google_compute_instance.nat.name}"

--- a/gce/network-subnet.tf
+++ b/gce/network-subnet.tf
@@ -1,11 +1,11 @@
 /* Networks */
 resource "google_compute_network" "network1" {
-  name = "tsuru-network1"
+  name = "tsuru-network1-${var.env}"
   ipv4_range = "${var.network1_cidr}"
 }
 
 resource "google_compute_route" "private_default" {
-  name = "private-default"
+  name = "private-default-${var.env}"
   dest_range = "0.0.0.0/0"
   network = "${google_compute_network.network1.name}"
   next_hop_instance = "${google_compute_instance.nat.name}"

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -2,12 +2,12 @@ output "api.*.private_ip" {
   value = "${join(",", google_compute_instance.api.*.network_interface.0.address)}"
 }
 
-output "app.0.private_ip" {
-  value = "${google_compute_instance.tsuru-app.0.network_interface.0.address}"
+output "db.private_ip" {
+  value = "${google_compute_instance.db.network_interface.0.address}"
 }
 
 output "docker.private_ip" {
-  value = "${google_compute_instance.tsuru-docker.network_interface.0.address}"
+  value = "${google_compute_instance.docker.network_interface.0.address}"
 }
 
 output "docker-registry.private_ip" {
@@ -31,7 +31,7 @@ output "postgres.private_ip" {
 }
 
 output "sslproxy.*.private_ip" {
-  value = "${join(",", google_compute_instance.tsuru-sslproxy.*.network_interface.0.address)}"
+  value = "${join(",", google_compute_instance.sslproxy.*.network_interface.0.address)}"
 }
 
 output "router.*.private_ip" {

--- a/gce/postgres-server.tf
+++ b/gce/postgres-server.tf
@@ -1,6 +1,6 @@
 /* Postgres Server Instance */
 resource "google_compute_instance" "postgres" {
-  name = "tsuru-postgres-${var.env}"
+  name = "${var.env}-tsuru-postgres"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/postgres-server.tf
+++ b/gce/postgres-server.tf
@@ -1,6 +1,6 @@
 /* Postgres Server Instance */
 resource "google_compute_instance" "postgres" {
-  name = "tsuru-postgres"
+  name = "tsuru-postgres-${var.env}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/routers.tf
+++ b/gce/routers.tf
@@ -1,7 +1,7 @@
 /* Routers */
 resource "google_compute_instance" "router" {
   count = 2
-  name = "tsuru-router-${count.index}"
+  name = "tsuru-router-${var.env}-${count.index}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -21,15 +21,15 @@ resource "google_compute_instance" "router" {
 
 /* Router load balancer */
 resource "google_compute_target_pool" "router" {
-  name = "tsuru-router-lb"
+  name = "tsuru-router-lb-${var.env}"
   instances = [ "${google_compute_instance.router.*.self_link}" ]
 }
 resource "google_compute_forwarding_rule" "router" {
-  name = "tsuru-router-lb"
+  name = "tsuru-router-lb-${var.env}"
   target = "${google_compute_target_pool.router.self_link}"
   port_range = 80
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} hipache.${var.dns_zone_name} 60 A ${google_compute_forwarding_rule.router.ip_address}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} hipache-${var.env}.${var.dns_zone_name} 60 A ${google_compute_forwarding_rule.router.ip_address}"
   }
 }

--- a/gce/routers.tf
+++ b/gce/routers.tf
@@ -1,7 +1,7 @@
 /* Routers */
 resource "google_compute_instance" "router" {
   count = 2
-  name = "tsuru-router-${var.env}-${count.index}"
+  name = "${var.env}-tsuru-router-${count.index}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -21,15 +21,15 @@ resource "google_compute_instance" "router" {
 
 /* Router load balancer */
 resource "google_compute_target_pool" "router" {
-  name = "tsuru-router-lb-${var.env}"
+  name = "${var.env}-tsuru-router-lb"
   instances = [ "${google_compute_instance.router.*.self_link}" ]
 }
 resource "google_compute_forwarding_rule" "router" {
-  name = "tsuru-router-lb-${var.env}"
+  name = "${var.env}-tsuru-router-lb"
   target = "${google_compute_target_pool.router.self_link}"
   port_range = 80
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} hipache-${var.env}.${var.dns_zone_name} 60 A ${google_compute_forwarding_rule.router.ip_address}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} ${var.env}-hipache.${var.dns_zone_name} 60 A ${google_compute_forwarding_rule.router.ip_address}"
   }
 }

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -1,6 +1,6 @@
 /* Internal security group */
 resource "google_compute_firewall" "internal" {
-  name = "tsuru-internal-${var.env}"
+  name = "${var.env}-tsuru-internal"
   description = "Security group for internally routed traffic"
   network = "${google_compute_network.network1.name}"
 
@@ -14,7 +14,7 @@ resource "google_compute_firewall" "internal" {
 
 /* Security group for the nat server */
 resource "google_compute_firewall" "nat" {
-  name = "nat-tsuru-${var.env}"
+  name = "${var.env}-nat-tsuru"
   description = "Security group for nat instances that allows SSH and VPN traffic from internet"
   network = "${google_compute_network.network1.name}"
 
@@ -29,7 +29,7 @@ resource "google_compute_firewall" "nat" {
 
 /* Security group for the Gandalf server */
 resource "google_compute_firewall" "gandalf" {
-  name = "tsuru-gandalf-${var.env}"
+  name = "${var.env}-tsuru-gandalf"
   description = "Security group for Gandalf instance that allows SSH access from internet"
   network = "${google_compute_network.network1.name}"
 
@@ -44,7 +44,7 @@ resource "google_compute_firewall" "gandalf" {
 
 /* Security group for the web */
 resource "google_compute_firewall" "web" {
-  name = "web-tsuru-${var.env}"
+  name = "${var.env}-web-tsuru"
   description = "Security group for web that allows web traffic from internet"
   network = "${google_compute_network.network1.name}"
 

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -1,6 +1,6 @@
 /* Internal security group */
 resource "google_compute_firewall" "internal" {
-  name = "tsuru-internal"
+  name = "tsuru-internal-${var.env}"
   description = "Security group for internally routed traffic"
   network = "${google_compute_network.network1.name}"
 
@@ -14,7 +14,7 @@ resource "google_compute_firewall" "internal" {
 
 /* Security group for the nat server */
 resource "google_compute_firewall" "nat" {
-  name = "nat-tsuru"
+  name = "nat-tsuru-${var.env}"
   description = "Security group for nat instances that allows SSH and VPN traffic from internet"
   network = "${google_compute_network.network1.name}"
 
@@ -29,7 +29,7 @@ resource "google_compute_firewall" "nat" {
 
 /* Security group for the Gandalf server */
 resource "google_compute_firewall" "gandalf" {
-  name = "tsuru-gandalf"
+  name = "tsuru-gandalf-${var.env}"
   description = "Security group for Gandalf instance that allows SSH access from internet"
   network = "${google_compute_network.network1.name}"
 
@@ -44,7 +44,7 @@ resource "google_compute_firewall" "gandalf" {
 
 /* Security group for the web */
 resource "google_compute_firewall" "web" {
-  name = "web-tsuru"
+  name = "web-tsuru-${var.env}"
   description = "Security group for web that allows web traffic from internet"
   network = "${google_compute_network.network1.name}"
 

--- a/gce/ssl-proxies.tf
+++ b/gce/ssl-proxies.tf
@@ -1,7 +1,7 @@
 /* SSL proxy */
 resource "google_compute_instance" "sslproxy" {
   count = 2
-  name = "tsuru-sslproxy-${var.env}-${count.index}"
+  name = "${var.env}-tsuru-sslproxy-${count.index}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -21,28 +21,27 @@ resource "google_compute_instance" "sslproxy" {
 
 /* SSL proxy load balancer */
 resource "google_compute_target_pool" "tsuru-sslproxy" {
-  name = "tsuru-sslproxy-lb-${var.env}"
+  name = "${var.env}-tsuru-sslproxy-lb"
   instances = [ "${google_compute_instance.sslproxy.*.self_link}" ]
   health_checks = [ "${google_compute_http_health_check.http-check.name}" ]
 }
 resource "google_compute_address" "tsuru-sslproxy" {
-  name = "tsuru-sslproxy-${var.env}"
+  name = "${var.env}-tsuru-sslproxy"
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} proxy-${var.env}.${var.dns_zone_name} 60 A ${google_compute_address.tsuru-sslproxy.address}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} ${var.env}-proxy.${var.dns_zone_name} 60 A ${google_compute_address.tsuru-sslproxy.address}"
   }
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} *.hipache-${var.env}.${var.dns_zone_name} 60 CNAME proxy-${var.env}.${var.dns_zone_name}."
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} *.${var.env}-hipache.${var.dns_zone_name} 60 CNAME ${var.env}-proxy.${var.dns_zone_name}."
   }
-}
-resource "google_compute_forwarding_rule" "tsuru-sslproxy-443" {
-  name = "tsuru-sslproxy-lb443-${var.env}"
+}resource "google_compute_forwarding_rule" "tsuru-sslproxy-443" {
+  name = "${var.env}-tsuru-sslproxy-lb443"
   target = "${google_compute_target_pool.tsuru-sslproxy.self_link}"
   port_range = 443
   ip_address = "${google_compute_address.tsuru-sslproxy.address}"
 }
 resource "google_compute_forwarding_rule" "tsuru-sslproxy-80" {
-  name = "tsuru-sslproxy-lb80-${var.env}"
+  name = "${var.env}-tsuru-sslproxy-lb80"
   target = "${google_compute_target_pool.tsuru-sslproxy.self_link}"
   port_range = 80
   ip_address = "${google_compute_address.tsuru-sslproxy.address}"

--- a/gce/ssl-proxies.tf
+++ b/gce/ssl-proxies.tf
@@ -1,7 +1,7 @@
 /* SSL proxy */
 resource "google_compute_instance" "tsuru-sslproxy" {
   count = 2
-  name = "tsuru-sslproxy-${count.index}"
+  name = "tsuru-sslproxy-${var.env}-${count.index}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -21,28 +21,28 @@ resource "google_compute_instance" "tsuru-sslproxy" {
 
 /* SSL proxy load balancer */
 resource "google_compute_target_pool" "tsuru-sslproxy" {
-  name = "tsuru-sslproxy-lb"
+  name = "tsuru-sslproxy-lb-${var.env}"
   instances = [ "${google_compute_instance.tsuru-sslproxy.*.self_link}" ]
   health_checks = [ "${google_compute_http_health_check.http-check.name}" ]
 }
 resource "google_compute_address" "tsuru-sslproxy" {
-  name = "tsuru-sslproxy"
+  name = "tsuru-sslproxy-${var.env}"
 
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} proxy.${var.dns_zone_name} 60 A ${google_compute_address.tsuru-sslproxy.address}"
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} proxy-${var.env}.${var.dns_zone_name} 60 A ${google_compute_address.tsuru-sslproxy.address}"
   }
   provisioner "local-exec" {
-    command = "./ensure_gce_dns.sh ${var.dns_zone_id} *.hipache.${var.dns_zone_name} 60 CNAME proxy.${var.dns_zone_name}."
+    command = "./ensure_gce_dns.sh ${var.dns_zone_id} *.hipache-${var.env}.${var.dns_zone_name} 60 CNAME proxy-${var.env}.${var.dns_zone_name}."
   }
 }
 resource "google_compute_forwarding_rule" "tsuru-sslproxy-443" {
-  name = "tsuru-sslproxy-lb443"
+  name = "tsuru-sslproxy-lb443-${var.env}"
   target = "${google_compute_target_pool.tsuru-sslproxy.self_link}"
   port_range = 443
   ip_address = "${google_compute_address.tsuru-sslproxy.address}"
 }
 resource "google_compute_forwarding_rule" "tsuru-sslproxy-80" {
-  name = "tsuru-sslproxy-lb80"
+  name = "tsuru-sslproxy-lb80-${var.env}"
   target = "${google_compute_target_pool.tsuru-sslproxy.self_link}"
   port_range = 80
   ip_address = "${google_compute_address.tsuru-sslproxy.address}"

--- a/gce/ssl-proxies.tf
+++ b/gce/ssl-proxies.tf
@@ -1,5 +1,5 @@
 /* SSL proxy */
-resource "google_compute_instance" "tsuru-sslproxy" {
+resource "google_compute_instance" "sslproxy" {
   count = 2
   name = "tsuru-sslproxy-${var.env}-${count.index}"
   machine_type = "n1-standard-1"
@@ -22,7 +22,7 @@ resource "google_compute_instance" "tsuru-sslproxy" {
 /* SSL proxy load balancer */
 resource "google_compute_target_pool" "tsuru-sslproxy" {
   name = "tsuru-sslproxy-lb-${var.env}"
-  instances = [ "${google_compute_instance.tsuru-sslproxy.*.self_link}" ]
+  instances = [ "${google_compute_instance.sslproxy.*.self_link}" ]
   health_checks = [ "${google_compute_http_health_check.http-check.name}" ]
 }
 resource "google_compute_address" "tsuru-sslproxy" {

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -18,6 +18,10 @@ variable "gce_zones" {
   default = "europe-west1-b,europe-west1-c,europe-west1-d"
 }
 
+variable "env" {
+  description = "Environment name"
+}
+
 variable "ssh_key_path" {
   description = "Path to the ssh key to use"
   default = "../ssh/insecure-deployer.pub"


### PR DESCRIPTION
[Create independent environments automatically](https://www.pivotaltracker.com/n/projects/1275640/stories/93688938)

This PR implements the possibility to create isolated and independent GCE environments, based on a parameter passed to Terraform. e.g.:
`terraform apply -var 'env=prod'`

I paired with @jimconner on this.
