### PR TITLE
Moved var.env suffix to prefix

### DIFF
--- a/aws/postgres-server.tf
+++ b/aws/postgres-server.tf
@@ -6,6 +6,6 @@ resource "aws_instance" "postgres" {
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${var.key_pair_name}"
   tags = {
-    Name = "tsuru-postgres-${var.env}"
+    Name = "${var.env}-tsuru-postgres"
   }
 }


### PR DESCRIPTION
Somehow managed to miss this one in the pull request.
