### PR TITLE
Rename instance docker-registry to tsuru-registry

### DIFF
--- a/aws/docker-registry.tf
+++ b/aws/docker-registry.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "docker-registry" {
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${var.key_pair_name}"
   tags = {
-    Name = "${var.env}-docker-registry"
+    Name = "${var.env}-tsuru-registry"
   }
   root_block_device {
     volume_type = "gp2"

--- a/gce/docker-registry.tf
+++ b/gce/docker-registry.tf
@@ -1,6 +1,6 @@
 /* Docker Registry */
 resource "google_compute_instance" "docker-registry" {
-  name = "${var.env}-docker-registry"
+  name = "${var.env}-tsuru-registry"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {


### PR DESCRIPTION
I think it's more important to have Tsuru in the name than Docker. This
makes it match the same pattern as all of the other instance names.
