### PR TITLE
[#93548898] aws: Replace ASGs with instances+count

### DIFF
--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,3 +1,7 @@
+output "api.*.ip" {
+  value = "${join(",", aws_instance.api.*.private_ip)}"
+}
+
 output "tsuru-db.ip" {
   value = "${aws_instance.tsuru-db.private_ip}"
 }
@@ -24,6 +28,14 @@ output "nat.ip" {
 
 output "postgres.private_ip" {
   value = "${aws_instance.postgres.private_ip}"
+}
+
+output "router.*.ip" {
+  value = "${join(",", aws_instance.router.*.private_ip)}"
+}
+
+output "sslproxy.*.ip" {
+  value = "${join(",", aws_instance.tsuru-sslproxy.*.private_ip)}"
 }
 
 output "elb.hostname" {

--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -1,28 +1,13 @@
 /* Router Launch configuration */
-resource "aws_launch_configuration" "router" {
-  image_id = "${lookup(var.amis, var.region)}"
+resource "aws_instance" "router" {
+  count = 2
+  ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
+  subnet_id = "${aws_subnet.private1.id}"
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${var.key_pair_name}"
-}
-
-/* Router Autoscaling Group */
-resource "aws_autoscaling_group" "router" {
-  availability_zones = ["${var.region}a", "${var.region}b"]
-  vpc_zone_identifier = ["${aws_subnet.private1.id}", "${aws_subnet.private2.id}"]
-  name = "${var.env}-tsuru-router-asg"
-  max_size = 5
-  min_size = 2
-  health_check_grace_period = 300
-  health_check_type = "EC2"
-  desired_capacity = 2
-  force_delete = true
-  launch_configuration = "${aws_launch_configuration.router.name}"
-  load_balancers = ["${aws_elb.router.name}", "${aws_elb.router-int.name}"]
-  tag = {
-    key = "Name"
-    value = "${var.env}-tsuru-app-router"
-    propagate_at_launch = true
+  tags = {
+    Name = "${var.env}-tsuru-app-router"
   }
 }
 
@@ -31,6 +16,8 @@ resource "aws_elb" "router" {
   name = "${var.env}-tsuru-router-elb"
   subnets = ["${aws_subnet.public1.id}", "${aws_subnet.public2.id}"]
   security_groups = ["${aws_security_group.default.id}", "${aws_security_group.web.id}"]
+  instances = ["${aws_instance.router.*.id}"]
+
   listener {
     instance_port = 80
     instance_protocol = "http"
@@ -45,6 +32,8 @@ resource "aws_elb" "router-int" {
   subnets = ["${aws_subnet.private1.id}", "${aws_subnet.private2.id}"]
   internal = true
   security_groups = ["${aws_security_group.default.id}", "${aws_security_group.web-int.id}"]
+  instances = ["${aws_instance.router.*.id}"]
+
   listener {
     instance_port = 80
     instance_protocol = "http"
@@ -52,4 +41,3 @@ resource "aws_elb" "router-int" {
     lb_protocol = "http"
   }
 }
-

--- a/aws/ssl-proxies.tf
+++ b/aws/ssl-proxies.tf
@@ -1,28 +1,13 @@
 /* SSL proxy Launch configuration */
-resource "aws_launch_configuration" "tsuru-sslproxy" {
-  image_id = "${lookup(var.amis, var.region)}"
+resource "aws_instance" "tsuru-sslproxy" {
+  count = 2
+  ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
   security_groups = ["${aws_security_group.default.id}","${aws_security_group.sslproxy.id}"]
+  subnet_id = "${aws_subnet.sslproxy1.id}"
   key_name = "${var.key_pair_name}"
-}
-
-/* SSL proxy Autoscaling Group */
-resource "aws_autoscaling_group" "tsuru-sslproxy-asg" {
-  availability_zones = ["${var.region}a", "${var.region}b"]
-  vpc_zone_identifier = ["${aws_subnet.sslproxy1.id}", "${aws_subnet.sslproxy2.id}"]
-  name = "${var.env}-tsuru-sslproxy-asg"
-  max_size = 2
-  min_size = 2
-  health_check_grace_period = 300
-  health_check_type = "EC2"
-  desired_capacity = 2
-  force_delete = true
-  launch_configuration = "${aws_launch_configuration.tsuru-sslproxy.name}"
-  load_balancers = ["${aws_elb.tsuru-sslproxy-elb.name}"]
-  tag = {
-    key = "Name"
-    value = "${var.env}-tsuru-sslproxy"
-    propagate_at_launch = true
+  tags = {
+    Name = "${var.env}-tsuru-sslproxy"
   }
 }
 
@@ -31,6 +16,8 @@ resource "aws_elb" "tsuru-sslproxy-elb" {
   name = "${var.env}-tsuru-sslproxy-elb"
   subnets = ["${aws_subnet.public1.id}", "${aws_subnet.public2.id}"]
   security_groups = ["${aws_security_group.default.id}", "${aws_security_group.sslproxy.id}"]
+  instances = ["${aws_instance.tsuru-sslproxy.*.id}"]
+
   listener {
     instance_port = 443
     instance_protocol = "tcp"

--- a/aws/to_delete.tf
+++ b/aws/to_delete.tf
@@ -1,0 +1,27 @@
+/*
+  This file contains resources that aren't in use but can't be deleted in a
+  single run because of dependency ordering. They should be removed from
+  this file at the earliest convenience after deploying to all existing
+  environments.
+*/
+
+resource "aws_launch_configuration" "api" {
+  image_id = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.medium"
+  security_groups = ["${aws_security_group.default.id}"]
+  key_name = "${var.key_pair_name}"
+}
+
+resource "aws_launch_configuration" "router" {
+  image_id = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.medium"
+  security_groups = ["${aws_security_group.default.id}"]
+  key_name = "${var.key_pair_name}"
+}
+
+resource "aws_launch_configuration" "tsuru-sslproxy" {
+  image_id = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.medium"
+  security_groups = ["${aws_security_group.default.id}","${aws_security_group.sslproxy.id}"]
+  key_name = "${var.key_pair_name}"
+}


### PR DESCRIPTION
Auto-scaling Groups have been problematic for us for two reasons:
- we can't easily use the launch configuration to run Ansible on instance
  creation because we're using delegation and it would require open SSH
  access between machines
- they're not supported by Terraform on GCE so we have disparity between the
  two sets of configs

So replace them with normal instances and `count` to create multiples of
them. Now that Terraform knows about the instances themselves we will be
able to use its state file to drive Ansible's inventory. I've added
additional outputs of these instances like we have for GCE so that we can
input them into the inventory for the timebeing.

We may later periodically run Terraform to ensure that we have the desired
state and we could dynamically adjust the counts.

In it's current form this puts all of the instances into the same
availability zone (default is the first). I'll address this in a following
commit. It's not trivial to do because subnets are also tied to AZs.

I've kept the launch configs and moved them to a separate file, indicating
that they should later be removed, because Terraform doesn't know about the
relationships when destroying unmanaged resources from the statefile and was
failing with:

```
aws_launch_configuration.tsuru-sslproxy: Destroying...
aws_launch_configuration.api: Destroying...
aws_launch_configuration.router: Destroying...
Error applying plan:

3 error(s) occurred:

* Cannot delete launch configuration terraform-Sz66CQVUUQF3rN9tyDP5xdLPkX0= because it is attached to AutoScalingGroup dcarley-tsuru-api-asg
* Cannot delete launch configuration terraform-lj1WhKZSBN8NMqI9bgdYZ7OsYzc= because it is attached to AutoScalingGroup dcarley-tsuru-sslproxy-asg
* Cannot delete launch configuration terraform-lpuvad7RYsnJrKSNRq2S7ckT09Q= because it is attached to AutoScalingGroup dcarley-tsuru-router-asg
```
