### PR TITLE
Remove extra ssh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ aws/ssh/
 gce/terraform.tfstate*
 gce/ssh/
 gce/account.json
-ssh/

--- a/README.md
+++ b/README.md
@@ -12,19 +12,21 @@ You need the cloud provider credentials. These will be entered on the command li
 
 1. The terraform provider for GCE requires access to an 'account.json' file - this is available from GCE's web interface in the 'credentials' section.
 
-Please note, for our team this is currently shared as it's not clear that we can create multiple accounts. If you are on the team please obtain the credentials from someone else. There is a [story in our backlog](https://www.pivotaltracker.com/n/projects/1275640/stories/93990946) to address this.
+  Please note, for our team this is currently shared as it's not clear that we can create multiple accounts. If you are on the team please obtain the credentials from someone else. There is a [story in our backlog](https://www.pivotaltracker.com/n/projects/1275640/stories/93990946) to address this.
 
 2. The GCE provider for Terraform does not currently have support for managing DNS records, and as such we have created a wrapper around Google's 'gcloud' command which allows us to create DNS records as part of a local-provisioner step. It is necessary to manually install the 'gcloud' command line utility and authenticate it before running Terraform for the first time.
 
-`$ curl https://sdk.cloud.google.com | bash`
+````
+  $ curl https://sdk.cloud.google.com | bash
 
-`$ gcloud components update`
+  $ gcloud components update
 
-`$ gcloud auth activate-service-account --key-file ~/path/to/account.json`
+  $ gcloud auth activate-service-account --key-file ~/path/to/account.json
 
-`$gcloud config set project <name_of_project_in_GCE>`
+  $gcloud config set project <name_of_project_in_GCE>
+````
 
-Once the above steps are complete, performing a  `gcloud compute instances list` will confirm that authentication is working as expected.
+  Once the above steps are complete, performing a  `gcloud compute instances list` will confirm that authentication is working as expected.
 
 
 ## Notes

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -24,7 +24,7 @@ variable "env" {
 
 variable "ssh_key_path" {
   description = "Path to the ssh key to use"
-  default = "../ssh/insecure-deployer.pub"
+  default = "ssh/insecure-deployer.pub"
 }
 
 variable "user" {


### PR DESCRIPTION
This PR tidies up two issues:
1. The fact that the previous set-up requires for GCE that the SSH key was duplicated in the root directory and in the GCE directory.
2. Minor formatting in the README.

Please see commit messages for more details.

Note that I have tested `terraform apply` and `terraform destroy` in GCE with this new set-up and it works fine.
