### PR TITLE
[#93688938] aws: Move all "private" records to "public" zone

### DIFF
--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -1,6 +1,6 @@
 /* Router CNAME record */
 resource "aws_route53_record" "router" {
-  zone_id = "${var.dns_zone_id_external}"
+  zone_id = "${var.dns_zone_id}"
   name = "${var.env}-hipache.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
@@ -8,7 +8,7 @@ resource "aws_route53_record" "router" {
 }
 
 resource "aws_route53_record" "sslproxy" {
-  zone_id = "${var.dns_zone_id_external}"
+  zone_id = "${var.dns_zone_id}"
   name = "${var.env}-proxy.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
@@ -17,7 +17,7 @@ resource "aws_route53_record" "sslproxy" {
 
 /* Internal Router CNAME record */
 resource "aws_route53_record" "router-int" {
-  zone_id = "${var.dns_zone_id_internal}"
+  zone_id = "${var.dns_zone_id}"
   name = "${var.env}-hipache-int.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
@@ -26,7 +26,7 @@ resource "aws_route53_record" "router-int" {
 
 /* Application router wildcard record */
 resource "aws_route53_record" "wildcard" {
-  zone_id = "${var.dns_zone_id_external}"
+  zone_id = "${var.dns_zone_id}"
   name = "*.${var.env}-hipache.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
@@ -38,7 +38,7 @@ resource "aws_route53_record" "wildcard" {
 
 /* API external CNAME record */
 resource "aws_route53_record" "api-external" {
-  zone_id = "${var.dns_zone_id_external}"
+  zone_id = "${var.dns_zone_id}"
   name = "${var.env}-api.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
@@ -47,7 +47,7 @@ resource "aws_route53_record" "api-external" {
 
 /* API internal CNAME record */
 resource "aws_route53_record" "api-internal" {
-  zone_id = "${var.dns_zone_id_internal}"
+  zone_id = "${var.dns_zone_id}"
   name = "${var.env}-internal.api.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
@@ -56,7 +56,7 @@ resource "aws_route53_record" "api-internal" {
 
 /* Gandalf A record */
 resource "aws_route53_record" "gandalf" {
-  zone_id = "${var.dns_zone_id_external}"
+  zone_id = "${var.dns_zone_id}"
   name = "${var.env}-gandalf.${var.dns_zone_name}"
   type = "A"
   ttl = "60"
@@ -65,7 +65,7 @@ resource "aws_route53_record" "gandalf" {
 
 /* NAT A record */
 resource "aws_route53_record" "nat" {
-  zone_id = "${var.dns_zone_id_external}"
+  zone_id = "${var.dns_zone_id}"
   name = "${var.env}-nat.${var.dns_zone_name}"
   type = "A"
   ttl = "60"
@@ -74,7 +74,7 @@ resource "aws_route53_record" "nat" {
 
 /* Docker-registry A record */
 resource "aws_route53_record" "docker-registry" {
-  zone_id = "${var.dns_zone_id_internal}"
+  zone_id = "${var.dns_zone_id}"
   name = "${var.env}-docker-registry.${var.dns_zone_name}"
   type = "A"
   ttl = "60"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -72,13 +72,8 @@ variable "api_ssl_certificate_id" {
   default = "arn:aws:iam::988997429095:server-certificate/wildcard_tsuru_paas_alphagov" 
 }
 
-variable "dns_zone_id_internal" {
-  description = "Amazon Route53 DNS zone identifier (internal)"
-  default = "Z3OIOPK20MYIOI"
-}
-
-variable "dns_zone_id_external" {
-  description = "Amazon Route53 DNS zone identifier (external)"
+variable "dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier"
   default = "ZAO40KKT7J2PB"
 }
 


### PR DESCRIPTION
The one existing private zone (referred to by zone ID) needed to be
associated with each new independent VPC. Terraform isn't able to do this
because it doesn't manage that existing private zone and doing it by hand
would be too cumbersome. This was documented in the story but not the
README.

This meant that machines were unable to resolve the addresses of internal
ELBs and failed to configure Nginx, in the example of the following Ansible
inventory item:

```
[hipache]
xx.xx.xx.xx internal_ip=dcarley-hipache-int.tsuru.paas.alphagov.co.uk
```

We could fix this by letting Terraform create and manage a separate private
zone for each independent environment. Since these don't have to be
delegated like public zones do.

However we're not using the split-horizon feature of private zones (our
records are namespaced to be "internal" and don't overlap with the public
records) and I'm not concerned about us exposing private IP addresses.

The current private zone will have to be deleted manually.
