### PR TITLE
[#93549792] Changed router names to match GCE

### DIFF
--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -8,7 +8,7 @@ resource "aws_instance" "router" {
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${var.key_pair_name}"
   tags = {
-    Name = "${var.env}-tsuru-app-router"
+    Name = "${var.env}-tsuru-router"
   }
 }
 


### PR DESCRIPTION
As we're using ansible to provision based on host names, it's rather important that the host names match between different cloud platforms. This change means that the hipache host names will match up.
