### PR TITLE
Add Jenkins static IP to security groups.

### DIFF
--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -3,15 +3,15 @@ resource "aws_security_group" "default" {
   name = "${var.env}-default-tsuru"
   description = "Default security group that allows inbound and outbound traffic from all instances in the VPC"
   vpc_id = "${aws_vpc.default.id}"
-  
+
   ingress {
     from_port   = "0"
     to_port     = "0"
     protocol    = "-1"
     self        = true
   }
-  
-  tags { 
+
+  tags {
     Name = "${var.env}-tsuru-default"
   }
 }
@@ -21,15 +21,15 @@ resource "aws_security_group" "nat" {
   name = "${var.env}-nat-tsuru"
   description = "Security group for nat instances that allows SSH and VPN traffic from internet"
   vpc_id = "${aws_vpc.default.id}"
-  
+
   ingress {
     from_port = 22
     to_port   = 22
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
   }
- 
-  tags { 
+
+  tags {
     Name = "${var.env}-tsuru-nat"
   }
 }
@@ -57,7 +57,7 @@ resource "aws_security_group" "web" {
   name = "${var.env}-web-tsuru"
   description = "Security group for web that allows web traffic from internet"
   vpc_id = "${aws_vpc.default.id}"
-  
+
   ingress {
     from_port = 80
     to_port   = 80
@@ -78,8 +78,8 @@ resource "aws_security_group" "web" {
     protocol  = "tcp"
     cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
- 
-  tags { 
+
+  tags {
     Name = "${var.env}-tsuru-web"
   }
 }
@@ -95,7 +95,7 @@ resource "aws_security_group" "web-int" {
     to_port     = 80
     protocol    = "tcp"
     cidr_blocks = ["${aws_subnet.sslproxy.*.cidr_block}"]
-  } 
+  }
 
  /* bug of terraform 0.4.2 does not work with  security groups this way. Workarounds above.
     ingress {
@@ -105,7 +105,7 @@ resource "aws_security_group" "web-int" {
     security_groups = ["${aws_security_group.sslproxy.id}"]
   } */
 
-  tags { 
+  tags {
     Name = "${var.env}-tsuru-web-int"
   }
 }
@@ -115,7 +115,7 @@ resource "aws_security_group" "sslproxy" {
   name = "${var.env}-tsuru-sslproxy"
   description = "Security group for sslproxy/offloader feedind the tsuru router elb"
   vpc_id = "${aws_vpc.default.id}"
-  
+
   ingress {
     from_port = 80
     to_port   = 80
@@ -129,8 +129,8 @@ resource "aws_security_group" "sslproxy" {
     protocol  = "tcp"
     cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
-  
-  tags { 
+
+  tags {
     Name = "${var.env}-tsuru-sslproxy"
   }
 }

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -18,7 +18,7 @@ resource "google_compute_firewall" "nat" {
   description = "Security group for nat instances that allows SSH and VPN traffic from internet"
   network = "${google_compute_network.network1.name}"
 
-  source_ranges = ["${split(",", var.office_cidrs)}"]
+  source_ranges = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
   target_tags = [ "nat" ]
 
   allow {

--- a/globals.tf
+++ b/globals.tf
@@ -3,6 +3,11 @@ variable "office_cidrs" {
   default     = "80.194.77.90/32,80.194.77.100/32"
 }
 
+variable "jenkins_elastic" {
+  description = "Elastic IP for Jenkins server which will be trusted"
+  default     = "52.17.162.85/32"
+}
+
 variable "health_check_interval" {
   description = "Interval between requests for load balancer health checks"
   default     = 5


### PR DESCRIPTION
Our jenkins provisioning server needs SSH access to the NAT boxes on AWS and GCE respectively.
It has been added to the same security groups which allow access from the office IPs.
