### PR TITLE
aws: Rename API internal DNS record

### DIFF
--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -48,7 +48,7 @@ resource "aws_route53_record" "api-external" {
 /* API internal CNAME record */
 resource "aws_route53_record" "api-internal" {
   zone_id = "${var.dns_zone_id}"
-  name = "${var.env}-internal.api.${var.dns_zone_name}"
+  name = "${var.env}-api-int.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
   records = ["${aws_elb.api-int.dns_name}"]


### PR DESCRIPTION
To be within the same sub-domain as everything else and match the convention
used by `hipache-int`. I have a feeling that this isn't actually being used
since we switch to dynamic inventory in alphagov/tsuru-ansible#41 so
changing this in-place shouldn't be disruptive.
