### PR TITLE
[#94593284] aws: Manage security group default egress rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-You need the terraform binary, e.g. `brew install terraform`.
+You need Terraform >= 0.5.0, e.g. `brew install terraform`.
 
 You need an SSH key. The private key needs to be chmod to 600.
 

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -4,6 +4,13 @@ resource "aws_security_group" "default" {
   description = "Default security group that allows inbound and outbound traffic from all instances in the VPC"
   vpc_id = "${aws_vpc.default.id}"
 
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   ingress {
     from_port   = "0"
     to_port     = "0"
@@ -21,6 +28,13 @@ resource "aws_security_group" "nat" {
   name = "${var.env}-nat-tsuru"
   description = "Security group for nat instances that allows SSH and VPN traffic from internet"
   vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   ingress {
     from_port = 22
@@ -40,6 +54,13 @@ resource "aws_security_group" "gandalf" {
   description = "Security group for Gandalf instance that allows SSH access from internet"
   vpc_id = "${aws_vpc.default.id}"
 
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   ingress {
     from_port = 22
     to_port   = 22
@@ -57,6 +78,13 @@ resource "aws_security_group" "web" {
   name = "${var.env}-web-tsuru"
   description = "Security group for web that allows web traffic from internet"
   vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   ingress {
     from_port = 80
@@ -90,7 +118,14 @@ resource "aws_security_group" "web-int" {
   description = "Security group for web that allows web traffic from internet"
   vpc_id = "${aws_vpc.default.id}"
 
-   ingress {
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
@@ -115,6 +150,13 @@ resource "aws_security_group" "sslproxy" {
   name = "${var.env}-tsuru-sslproxy"
   description = "Security group for sslproxy/offloader feedind the tsuru router elb"
   vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   ingress {
     from_port = 80


### PR DESCRIPTION
In order to prevent them from being removed when anyone upgrades to
Terraform 0.5.x - which may be as simple as a new starter installing the
current/latest available version. Per #50 and:
- https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#050-may-7-2015

When applied with Terraform 0.4.x this will initially result in an error but
the resource will still be placed in the statefile and you won't get errors
on subsequent runs:

```
* Error authorizing security group egress rules: the specified rule "peer: 0.0.0.0/0, ALL, ALLOW" already exists
```

It is advisable that we all upgrade to 0.5.x
