### PR TITLE
Remove all resource comments

### DIFF
--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -1,4 +1,3 @@
-/* API servers Launch configuration */
 resource "aws_instance" "api" {
   count = 2
   ami = "${lookup(var.amis, var.region)}"
@@ -12,7 +11,6 @@ resource "aws_instance" "api" {
   }
 }
 
-/* API external Load balancer */
 resource "aws_elb" "api-ext" {
   name = "${var.env}-tsuru-api-elb-ext"
   subnets = ["${aws_subnet.public.*.id}"]
@@ -41,7 +39,6 @@ resource "aws_elb" "api-ext" {
   }
 }
 
-/* API internal Load balancer */
 resource "aws_elb" "api-int" {
   name = "${var.env}-tsuru-api-elb-int"
   subnets = ["${aws_subnet.private.*.id}"]

--- a/aws/aws-vpc.tf
+++ b/aws/aws-vpc.tf
@@ -1,11 +1,9 @@
-/* Setup our aws provider */
 provider "aws" {
   access_key  = "${var.aws_access_key}"
   secret_key  = "${var.aws_secret_key}"
   region      = "${var.region}"
 }
 
-/* Define our vpc */
 resource "aws_vpc" "default" {
   cidr_block = "${var.vpc_cidr}"
   enable_dns_hostnames = true

--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -1,4 +1,3 @@
-/* Router CNAME record */
 resource "aws_route53_record" "router" {
   zone_id = "${var.dns_zone_id}"
   name = "${var.env}-hipache.${var.dns_zone_name}"
@@ -15,7 +14,6 @@ resource "aws_route53_record" "sslproxy" {
   records = ["${aws_elb.tsuru-sslproxy-elb.dns_name}"]
 }
 
-/* Internal Router CNAME record */
 resource "aws_route53_record" "router-int" {
   zone_id = "${var.dns_zone_id}"
   name = "${var.env}-hipache-int.${var.dns_zone_name}"
@@ -24,7 +22,6 @@ resource "aws_route53_record" "router-int" {
   records = ["${aws_elb.router-int.dns_name}"]
 }
 
-/* Application router wildcard record */
 resource "aws_route53_record" "wildcard" {
   zone_id = "${var.dns_zone_id}"
   name = "*.${var.env}-hipache.${var.dns_zone_name}"
@@ -36,7 +33,6 @@ resource "aws_route53_record" "wildcard" {
   records = ["${aws_route53_record.sslproxy.name}"]
 }
 
-/* API external CNAME record */
 resource "aws_route53_record" "api-external" {
   zone_id = "${var.dns_zone_id}"
   name = "${var.env}-api.${var.dns_zone_name}"
@@ -45,7 +41,6 @@ resource "aws_route53_record" "api-external" {
   records = ["${aws_elb.api-ext.dns_name}"]
 }
 
-/* API internal CNAME record */
 resource "aws_route53_record" "api-internal" {
   zone_id = "${var.dns_zone_id}"
   name = "${var.env}-api-int.${var.dns_zone_name}"
@@ -54,7 +49,6 @@ resource "aws_route53_record" "api-internal" {
   records = ["${aws_elb.api-int.dns_name}"]
 }
 
-/* Gandalf A record */
 resource "aws_route53_record" "gandalf" {
   zone_id = "${var.dns_zone_id}"
   name = "${var.env}-gandalf.${var.dns_zone_name}"
@@ -63,7 +57,6 @@ resource "aws_route53_record" "gandalf" {
   records = ["${aws_instance.gandalf.public_ip}"]
 }
 
-/* NAT A record */
 resource "aws_route53_record" "nat" {
   zone_id = "${var.dns_zone_id}"
   name = "${var.env}-nat.${var.dns_zone_name}"
@@ -72,7 +65,6 @@ resource "aws_route53_record" "nat" {
   records = ["${aws_instance.nat.public_ip}"]
 }
 
-/* Docker-registry A record */
 resource "aws_route53_record" "docker-registry" {
   zone_id = "${var.dns_zone_id}"
   name = "${var.env}-docker-registry.${var.dns_zone_name}"
@@ -80,4 +72,3 @@ resource "aws_route53_record" "docker-registry" {
   ttl = "60"
   records = ["${aws_instance.docker-registry.private_ip}"]
 }
-

--- a/aws/docker-registry.tf
+++ b/aws/docker-registry.tf
@@ -1,4 +1,3 @@
-/* Docker Registry */
 resource "aws_instance" "docker-registry" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"

--- a/aws/docker-servers.tf
+++ b/aws/docker-servers.tf
@@ -1,4 +1,3 @@
-/* Docker server */
 resource "aws_instance" "tsuru-docker" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"

--- a/aws/gandalf.tf
+++ b/aws/gandalf.tf
@@ -1,4 +1,3 @@
-/* Gandalf server */
 resource "aws_instance" "gandalf" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"

--- a/aws/mongo-redis.tf
+++ b/aws/mongo-redis.tf
@@ -1,4 +1,3 @@
-/* MongoDB and Redis DB server */
 resource "aws_instance" "tsuru-db" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"

--- a/aws/nat-server.tf
+++ b/aws/nat-server.tf
@@ -1,4 +1,3 @@
-/* NAT/VPN server */
 resource "aws_instance" "nat" {
   ami = "${lookup(var.nat_ami, var.region)}"
   instance_type = "t2.micro"

--- a/aws/postgres-server.tf
+++ b/aws/postgres-server.tf
@@ -1,4 +1,3 @@
-/* Single instance postgres server */
 resource "aws_instance" "postgres" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.micro"

--- a/aws/private-subnet.tf
+++ b/aws/private-subnet.tf
@@ -1,4 +1,3 @@
-/* Private subnets */
 resource "aws_subnet" "private" {
   count             = 2
   vpc_id            = "${aws_vpc.default.id}"
@@ -11,7 +10,6 @@ resource "aws_subnet" "private" {
   }
 }
 
-/* Routing table for private subnets */
 resource "aws_route_table" "private" {
   vpc_id = "${aws_vpc.default.id}"
   route {
@@ -20,7 +18,6 @@ resource "aws_route_table" "private" {
   }
 }
 
-/* Associate the routing table to private subnets */
 resource "aws_route_table_association" "private" {
   count = 2
   subnet_id = "${element(aws_subnet.private.*.id, count.index)}"

--- a/aws/public-subnet.tf
+++ b/aws/public-subnet.tf
@@ -1,9 +1,7 @@
-/* Internet gateway for the public subnet */
 resource "aws_internet_gateway" "default" {
   vpc_id = "${aws_vpc.default.id}"
 }
 
-/* Public subnets */
 resource "aws_subnet" "public" {
   count             = 2
   vpc_id            = "${aws_vpc.default.id}"
@@ -16,7 +14,6 @@ resource "aws_subnet" "public" {
   }
 }
 
-/* Routing table for public subnets */
 resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.default.id}"
   route {
@@ -25,7 +22,6 @@ resource "aws_route_table" "public" {
   }
 }
 
-/* Associate the routing tables */
 resource "aws_route_table_association" "public" {
   count = 2
   subnet_id = "${element(aws_subnet.public.*.id, count.index)}"

--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -1,4 +1,3 @@
-/* Router Launch configuration */
 resource "aws_instance" "router" {
   count = 2
   ami = "${lookup(var.amis, var.region)}"
@@ -12,7 +11,6 @@ resource "aws_instance" "router" {
   }
 }
 
-/* Router External Load balancer */
 resource "aws_elb" "router" {
   name = "${var.env}-tsuru-router-elb"
   subnets = ["${aws_subnet.public.*.id}"]
@@ -34,7 +32,6 @@ resource "aws_elb" "router" {
   }
 }
 
-/* Router Internal Load balancer */
 resource "aws_elb" "router-int" {
   name = "${var.env}-tsuru-router-elb-int"
   subnets = ["${aws_subnet.private.*.id}"]

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -1,4 +1,3 @@
-/* Default security group */
 resource "aws_security_group" "default" {
   name = "${var.env}-default-tsuru"
   description = "Default security group that allows inbound and outbound traffic from all instances in the VPC"
@@ -16,7 +15,6 @@ resource "aws_security_group" "default" {
   }
 }
 
-/* Security group for the nat server */
 resource "aws_security_group" "nat" {
   name = "${var.env}-nat-tsuru"
   description = "Security group for nat instances that allows SSH and VPN traffic from internet"
@@ -34,7 +32,6 @@ resource "aws_security_group" "nat" {
   }
 }
 
-/* Security group for the Gandalf server */
 resource "aws_security_group" "gandalf" {
   name = "${var.env}-tsuru-gandalf"
   description = "Security group for Gandalf instance that allows SSH access from internet"
@@ -52,7 +49,6 @@ resource "aws_security_group" "gandalf" {
   }
 }
 
-/* Security group for the web */
 resource "aws_security_group" "web" {
   name = "${var.env}-web-tsuru"
   description = "Security group for web that allows web traffic from internet"
@@ -84,7 +80,6 @@ resource "aws_security_group" "web" {
   }
 }
 
-/* Security group for the web */
 resource "aws_security_group" "web-int" {
   name = "${var.env}-web-int-tsuru"
   description = "Security group for web that allows web traffic from internet"
@@ -110,7 +105,6 @@ resource "aws_security_group" "web-int" {
   }
 }
 
-/* Security group for the sslproxy */
 resource "aws_security_group" "sslproxy" {
   name = "${var.env}-tsuru-sslproxy"
   description = "Security group for sslproxy/offloader feedind the tsuru router elb"

--- a/aws/ssl-proxies.tf
+++ b/aws/ssl-proxies.tf
@@ -1,4 +1,3 @@
-/* SSL proxy Launch configuration */
 resource "aws_instance" "tsuru-sslproxy" {
   count = 2
   ami = "${lookup(var.amis, var.region)}"
@@ -12,7 +11,6 @@ resource "aws_instance" "tsuru-sslproxy" {
   }
 }
 
-/* SSL proxy Load balancer */
 resource "aws_elb" "tsuru-sslproxy-elb" {
   name = "${var.env}-tsuru-sslproxy-elb"
   subnets = ["${aws_subnet.public.*.id}"]

--- a/aws/sslproxy-subnet.tf
+++ b/aws/sslproxy-subnet.tf
@@ -1,4 +1,3 @@
-/* Private subnets */
 resource "aws_subnet" "sslproxy" {
   count             = 2
   vpc_id            = "${aws_vpc.default.id}"
@@ -11,7 +10,6 @@ resource "aws_subnet" "sslproxy" {
   }
 }
 
-/* Routing table for private subnets */
 resource "aws_route_table" "sslproxy" {
   vpc_id = "${aws_vpc.default.id}"
   route {
@@ -20,7 +18,6 @@ resource "aws_route_table" "sslproxy" {
   }
 }
 
-/* Associate the routing table to private subnets */
 resource "aws_route_table_association" "sslproxy" {
   count =2 
   subnet_id = "${element(aws_subnet.sslproxy.*.id, count.index)}"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -52,7 +52,6 @@ variable "sslproxy_cidrs" {
   }
 }
 
-/* Ubuntu 14.04 amis by region */
 variable "amis" {
   description = "Base AMI to launch the instances with"
   default = {

--- a/gce/api-servers.tf
+++ b/gce/api-servers.tf
@@ -1,4 +1,3 @@
-/* API server */
 resource "google_compute_instance" "api" {
   count = 2
   name = "${var.env}-tsuru-api-${count.index}"
@@ -19,7 +18,6 @@ resource "google_compute_instance" "api" {
   tags = [ "private", "web" ]
 }
 
-/* API load balancer */
 resource "google_compute_http_health_check" "api" {
   name = "${var.env}-tsuru-api"
   port = 8080

--- a/gce/docker-registry.tf
+++ b/gce/docker-registry.tf
@@ -1,4 +1,3 @@
-/* Docker Registry */
 resource "google_compute_instance" "docker-registry" {
   name = "${var.env}-tsuru-registry"
   machine_type = "n1-standard-1"

--- a/gce/docker-servers.tf
+++ b/gce/docker-servers.tf
@@ -1,4 +1,3 @@
-/* Docker server */
 resource "google_compute_instance" "docker" {
   name = "${var.env}-tsuru-docker"
   machine_type = "n1-standard-1"

--- a/gce/gandalf.tf
+++ b/gce/gandalf.tf
@@ -1,4 +1,3 @@
-/* Gandalf server */
 resource "google_compute_instance" "gandalf" {
   name = "${var.env}-tsuru-gandalf"
   machine_type = "n1-standard-1"

--- a/gce/mongo-redis.tf
+++ b/gce/mongo-redis.tf
@@ -1,4 +1,3 @@
-/* MongoDB and Redis DB server */
 resource "google_compute_instance" "db" {
   name = "${var.env}-tsuru-db"
   machine_type = "n1-standard-1"

--- a/gce/nat-server.tf
+++ b/gce/nat-server.tf
@@ -1,4 +1,3 @@
-/* Jumpbox Server Instance */
 resource "google_compute_instance" "nat" {
   name = "${var.env}-tsuru-nat"
   machine_type = "n1-standard-1"

--- a/gce/network-subnet.tf
+++ b/gce/network-subnet.tf
@@ -1,4 +1,3 @@
-/* Networks */
 resource "google_compute_network" "network1" {
   name = "${var.env}-tsuru-network1"
   ipv4_range = "${var.network1_cidr}"

--- a/gce/postgres-server.tf
+++ b/gce/postgres-server.tf
@@ -1,4 +1,3 @@
-/* Postgres Server Instance */
 resource "google_compute_instance" "postgres" {
   name = "${var.env}-tsuru-postgres"
   machine_type = "n1-standard-1"

--- a/gce/routers.tf
+++ b/gce/routers.tf
@@ -1,4 +1,3 @@
-/* Routers */
 resource "google_compute_instance" "router" {
   count = 2
   name = "${var.env}-tsuru-router-${count.index}"
@@ -19,7 +18,6 @@ resource "google_compute_instance" "router" {
   tags = [ "private", "web" ]
 }
 
-/* Router load balancer */
 resource "google_compute_target_pool" "router" {
   name = "${var.env}-tsuru-router-lb"
   instances = [ "${google_compute_instance.router.*.self_link}" ]

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -1,4 +1,3 @@
-/* Internal security group */
 resource "google_compute_firewall" "internal" {
   name = "${var.env}-tsuru-internal"
   description = "Security group for internally routed traffic"
@@ -12,7 +11,6 @@ resource "google_compute_firewall" "internal" {
   allow { protocol = "icmp" }
 }
 
-/* Security group for the nat server */
 resource "google_compute_firewall" "nat" {
   name = "${var.env}-nat-tsuru"
   description = "Security group for nat instances that allows SSH and VPN traffic from internet"
@@ -27,7 +25,6 @@ resource "google_compute_firewall" "nat" {
   }
 }
 
-/* Security group for the Gandalf server */
 resource "google_compute_firewall" "gandalf" {
   name = "${var.env}-tsuru-gandalf"
   description = "Security group for Gandalf instance that allows SSH access from internet"
@@ -42,7 +39,6 @@ resource "google_compute_firewall" "gandalf" {
   }
 }
 
-/* Security group for the web */
 resource "google_compute_firewall" "web" {
   name = "${var.env}-web-tsuru"
   description = "Security group for web that allows web traffic from internet"

--- a/gce/ssl-proxies.tf
+++ b/gce/ssl-proxies.tf
@@ -1,4 +1,3 @@
-/* SSL proxy */
 resource "google_compute_instance" "sslproxy" {
   count = 2
   name = "${var.env}-tsuru-sslproxy-${count.index}"
@@ -19,7 +18,6 @@ resource "google_compute_instance" "sslproxy" {
   tags = [ "private", "web" ]
 }
 
-/* SSL proxy load balancer */
 resource "google_compute_target_pool" "tsuru-sslproxy" {
   name = "${var.env}-tsuru-sslproxy-lb"
   instances = [ "${google_compute_instance.sslproxy.*.self_link}" ]


### PR DESCRIPTION
These comments duplicate what the Terraform resources already tell us;
particularly the type of resource and its name. They are also (like most
code comments) factually incorrect in places, such as the "launch configs"
which I forgot to update and are actually "instances" now.

```
find . -name \*.tf -type f -exec gsed -ri '/^\/\*/d' {} \+
```
