### PR TITLE
Add file for known errors when upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,7 @@ For usage, refer to the [Terraform CLI doc](https://www.terraform.io/docs/comman
 
 To create your own environment, you need to pass a variable of the name you want to give it, e.g. `terraform apply -var env=my-new-environment`.
 
+This should be enough to create a fresh environment. However, sometimes we make changes that mean you'll need to make other adjustments if you've previously created an environment. The file [upgrade_compatibility](/upgrade_compatibility.md) shows some of the errors you might see, and their solutions.
+
 We have found that `terraform destroy` doesn't work reliably. Possible cause [this issue](https://github.com/hashicorp/terraform/issues/1203). Workaround is to delete manually via the console.
 

--- a/upgrade_compatibility.md
+++ b/upgrade_compatibility.md
@@ -1,0 +1,12 @@
+# Upgrade Compatibility
+
+While we try and make all changes backwards-compatible, sometimes we have to make changes that mean you cannot cleanly provision a new environment.
+
+
+## DNS resources already exist
+
+Error:
+
+`Error creating DNS RecordSet: googleapi: Error 409: The resource 'entity.change.additions[0]' named 'env-proxy.tsuru2.paas.alphagov.co.uk. (A)' already exists, alreadyExists`
+
+This is caused by [7780fe9d](https://github.com/alphagov/tsuru-terraform/commit/7780fe9), which also contains the scrips you can use to fix it.


### PR DESCRIPTION
We try very hard to make changes backwards-compatible, but sometimes we do make changes that require additional changes to the environment. This adds a file to list these so that you don't have to trawl back through previous commits, e.g. if you've been on holiday...

---

Not sure about naming here; can anyone think of a better name for the file or is this good enough?

@dcarley and I already discussed this so it would be good for someone else to review.
