### PR TITLE
[#93705168] Create GCS bucket on GCE for docker registry

### DIFF
--- a/gce/docker-registry.tf
+++ b/gce/docker-registry.tf
@@ -17,3 +17,9 @@ resource "google_compute_instance" "docker-registry" {
   }
   tags = [ "private" ]
 }
+
+resource "google_storage_bucket" "registry-gcs" {
+    name = "${var.env}-${var.registry_gcs_bucketname}"
+    predefined_acl = "${var.registry_gcs_bucketname_acl}"
+    location = "${var.gcs_region}"
+}

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -51,3 +51,13 @@ variable "dns_zone_name" {
   description = "Google DNS zone name"
   default     = "tsuru2.paas.alphagov.co.uk."
 }
+
+variable "registry_gcs_bucketname" {
+  description = "GCS Object Storage name for the registry"
+  default = "mcp-registry-storage"
+}
+
+variable "registry_gcs_bucketname_acl" {
+  description = "GCS Bucket canned Access Control List"
+  default = "projectPrivate"
+}


### PR DESCRIPTION
[Registry uses GCS on GCE](https://www.pivotaltracker.com/story/show/93705168)

**What**
- Use `terraform` to create a `GCS` bucket for a private `docker registry` to host it's images.

**How this PR should be reviewed**
- This is a single commit to create a storage bucket that can be accessed by the docker registry.

**Who should review this PR**
- Anyone on the core team,
- I paired with @dhilton on this one so he isn't allowed to merge it! :p
