### PR TITLE
Allow jenkins to connect to gandalf and web LB

### DIFF
--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "gandalf" {
     from_port = 22
     to_port   = 22
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
   }
 
   tags {
@@ -86,21 +86,21 @@ resource "aws_security_group" "web" {
     from_port = 80
     to_port   = 80
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
   }
 
   ingress {
     from_port = 8080
     to_port   = 8080
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
   }
 
   ingress {
     from_port = 443
     to_port   = 443
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
   }
 
   tags {

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -30,7 +30,7 @@ resource "google_compute_firewall" "gandalf" {
   description = "Security group for Gandalf instance that allows SSH access from internet"
   network = "${google_compute_network.network1.name}"
 
-  source_ranges = ["${split(",", var.office_cidrs)}"]
+  source_ranges = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
   target_tags = [ "gandalf" ]
 
   allow {
@@ -45,7 +45,7 @@ resource "google_compute_firewall" "web" {
   network = "${google_compute_network.network1.name}"
 
   source_ranges = [
-    "${split(",", var.office_cidrs)}",
+    "${split(",", var.office_cidrs)}","${var.jenkins_elastic}",
     "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}",
     "${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}",
   ]


### PR DESCRIPTION
Give jenkins same access level as our office IP ranges, so that we can run jobs that deploy and check apps.
