### PR TITLE
[#93705168] Update service account scope for docker registry

### DIFF
--- a/gce/docker-registry.tf
+++ b/gce/docker-registry.tf
@@ -13,7 +13,7 @@ resource "google_compute_instance" "docker-registry" {
     sshKeys = "${var.user}:${file(\"${var.ssh_key_path}")}"
   }
   service_account {
-    scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
+    scopes = [ "compute-ro", "storage-rw", "userinfo-email" ]
   }
   tags = [ "private" ]
 }


### PR DESCRIPTION
[Registry uses GCS on GCE](https://www.pivotaltracker.com/n/projects/1275640/stories/93705168)

**What**

Change service account scope to `storage-rw` to allow docker registry
read-write access to the `gcs` bucket.

This will allow us to use [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials) to: 
- Allow the docker registry to get its authorization credentials by make api calls to google securely,
- Make it easier for the team to provision docker registries with out having to setup their own gcs access and secret keys.

This change is no breaking and will be followed up by a subsequent PR requests in:
- [codingbunch/ansible-docker-registry](https://github.com/codingbunch/ansible-docker-registry) - gcs support with[service account default credential support](https://developers.google.com/identity/protocols/application-default-credentials),
- [alphagov/tsuru-ansible](https://github.com/alphagov/tsuru-ansible) - Allow for the passing of no credentials what so ever to use [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).

**Who should review this PR**
- Anyone on the core team with the exception of moi!
