### PR TITLE
[#95697144] Firewall: Let nat-ed hosts connect to web

### DIFF
--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -86,21 +86,21 @@ resource "aws_security_group" "web" {
     from_port = 80
     to_port   = 80
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
   }
 
   ingress {
     from_port = 8080
     to_port   = 8080
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
   }
 
   ingress {
     from_port = 443
     to_port   = 443
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
   }
 
   tags {

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -48,6 +48,7 @@ resource "google_compute_firewall" "web" {
     "${split(",", var.office_cidrs)}","${var.jenkins_elastic}",
     "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}",
     "${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}",
+    "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}/32",
   ]
   target_tags = [ "web" ]
 


### PR DESCRIPTION
Allow hosts behing NAT, which includes e.g. API server to connect to main web interface of apps deployed on the plaform, which include e.g. postgresapi service broker.
