### PR TITLE
[#95697144] Open FW to let api server git push to gandalf

### DIFF
--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "gandalf" {
     from_port = 22
     to_port   = 22
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
   }
 
   tags {

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -30,7 +30,7 @@ resource "google_compute_firewall" "gandalf" {
   description = "Security group for Gandalf instance that allows SSH access from internet"
   network = "${google_compute_network.network1.name}"
 
-  source_ranges = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
+  source_ranges = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}/32"]
   target_tags = [ "gandalf" ]
 
   allow {


### PR DESCRIPTION
To do git push (to deploy dashboard and postgresapi), Api server needs to connect to port 22 on Gandalf. Add firewall rules enabling this.
