### PR TITLE
Use standard AWS credentials environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ The terraform provider for GCE requires access to an 'account.json' file - this 
 
 Please note, for our team this is currently shared as it's not clear that we can create multiple accounts. If you are on the team please obtain the credentials from someone else. There is a [story in our backlog](https://www.pivotaltracker.com/n/projects/1275640/stories/93990946) to address this.
 
+### Extra requirements for AWS provisioning
+
+The terraform provider for AWS will read the standard AWS credentials environment variables. You must have these variables exported:
+
+	AWS_ACCESS_KEY_ID
+	AWS_SECRET_ACCESS_KEY
+
+You can get the credentials from the AWS console.
+
 ## Notes
 
 Change into one of the provider sub-directories before executing `terraform` commands.

--- a/aws/aws-vpc.tf
+++ b/aws/aws-vpc.tf
@@ -1,6 +1,4 @@
 provider "aws" {
-  access_key  = "${var.aws_access_key}"
-  secret_key  = "${var.aws_secret_key}"
   region      = "${var.region}"
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,16 +1,8 @@
-variable "aws_access_key" { 
-  description = "AWS access key"
-}
-
-variable "aws_secret_key" { 
-  description = "AWS secert access key"
-}
-
 variable "env" {
   description = "Environment name"
 }
 
-variable "region"     { 
+variable "region"     {
   description = "AWS region"
   default     = "eu-west-1"
 }


### PR DESCRIPTION
Terraform [now supports get the AWS credentials  from the standard environment variables](https://github.com/hashicorp/terraform/pull/851).

To make it work, you should not specify 'access_key' or 'secret_key' in the provider definition.  We also need to remove the variables as we don't use them.

This will allow use to just run:

```
terraform apply -var env=hector
```

rather than:

```
terraform apply \
   -var env=hector \
   -var aws_access_key=$AWS_ACCESS_KEY_ID \
   -var aws_secret_key=$AWS_SECRET_ACCESS_KEY
```
