### PR TITLE
Remove one hop when resolving app name

### DIFF
--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -1,17 +1,9 @@
-resource "aws_route53_record" "router" {
-  zone_id = "${var.dns_zone_id}"
-  name = "${var.env}-hipache.${var.dns_zone_name}"
-  type = "CNAME"
-  ttl = "60"
-  records = ["${aws_elb.router.dns_name}"]
-}
-
 resource "aws_route53_record" "wildcard" {
   zone_id = "${var.dns_zone_id}"
   name = "*.${var.env}-hipache.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
-  records = ["${aws_route53_record.router.name}"]
+  records = ["${aws_elb.router.dns_name}"]
 }
 
 resource "aws_route53_record" "api-external" {

--- a/gce/dns-records.tf
+++ b/gce/dns-records.tf
@@ -1,17 +1,9 @@
-resource "google_dns_record_set" "router" {
-  managed_zone = "${var.dns_zone_id}"
-  name = "${var.env}-hipache.${var.dns_zone_name}"
-  type = "A"
-  ttl = "60"
-  rrdatas = ["${google_compute_forwarding_rule.router_https.ip_address}"]
-}
-
 resource "google_dns_record_set" "wildcard" {
   managed_zone = "${var.dns_zone_id}"
   name = "*.${var.env}-hipache.${var.dns_zone_name}"
-  type = "CNAME"
+  type = "A"
   ttl = "60"
-  rrdatas = ["${google_dns_record_set.router.name}"]
+  rrdatas = ["${google_compute_forwarding_rule.router_https.ip_address}"]
 }
 
 resource "google_dns_record_set" "api" {


### PR DESCRIPTION
Because of legacy configuration (2 LBs, one for SSL and one for HTTP) there is leftover configuration which redirects *.<env>-hipache.<DOMAIN> to either SSL or HTTP LBs - whichever you configure. We are now only using SSL. Therefore it's not necessary for this DNS record to point to <env>-hipache.<DOMAIN> which then points to the actual SSL Load Balancer, but we can point to the LB directly. This simplifies config and speeds up DNS resolution (one step less to resolve final LB IP). Switch to SSL only configuration was made in https://github.com/alphagov/tsuru-ansible/pull/69
