### PR TITLE
Create CNAME for <env>-postgresqlapi.<DOMAIN>

### DIFF
--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -53,3 +53,11 @@ resource "aws_route53_record" "docker-registry" {
   ttl = "60"
   records = ["${aws_instance.docker-registry.private_ip}"]
 }
+
+resource "aws_route53_record" "postgresapi" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-postgresapi.${var.dns_zone_name}"
+  type = "CNAME"
+  ttl = "60"
+  records = ["${aws_elb.router.dns_name}"]
+}

--- a/gce/dns-records.tf
+++ b/gce/dns-records.tf
@@ -45,3 +45,11 @@ resource "google_dns_record_set" "docker-registry" {
   ttl = "60"
   rrdatas = ["${google_compute_instance.docker-registry.network_interface.0.address}"]
 }
+
+resource "google_dns_record_set" "postgresapi" {
+  managed_zone = "${var.dns_zone_id}"
+  name = "${var.env}-postgresapi.${var.dns_zone_name}"
+  type = "A"
+  ttl = "60"
+  rrdatas = ["${google_compute_forwarding_rule.router_https.ip_address}"]
+}


### PR DESCRIPTION
To instanciate postgresql service instance, tsuru api needs to talk to the postgresqlapi app (which is postgresql broker). This happens over https. We only have certificate for *.<DOMAIN>, which doesn't match postgresqlapi.<env>-hipache.<DOMAIN>. To work around this, we are creating a CNAME record <env>-postgresqlapi.<DOMAIN> which points to the platform LB directly (same target as for *.<env>-hipache.<DOMAIN>). We also map this route to the postgresqlapi app inside Tsuru, so that hipache can route requests correctly. After this change, we register postgresqlapi broker on the <env>-postgresqlapi.<DOMAIN> URL. Tsuru API now talks to this URL which matches the *.<DOMAIN> certificate, hence all works.
