### PR TITLE
[#93541780] Add LB forward of HTTPS (tcp/443) to nginx for tsuru-api

### DIFF
--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -18,7 +18,7 @@ resource "aws_elb" "api-ext" {
   instances = ["${aws_instance.api.*.id}"]
 
   health_check {
-    target = "HTTP:8080/info"
+    target = "HTTPS:443/info"
     interval = "${var.health_check_interval}"
     timeout = "${var.health_check_timeout}"
     healthy_threshold = "${var.health_check_healthy}"
@@ -31,11 +31,10 @@ resource "aws_elb" "api-ext" {
     lb_protocol = "http"
   }
   listener {
-    instance_port = 8080
-    instance_protocol = "http"
+    instance_port = 443
+    instance_protocol = "tcp"
     lb_port = 443
-    lb_protocol = "https"
-    ssl_certificate_id = "${var.api_ssl_certificate_id}"
+    lb_protocol = "tcp"
   }
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -60,11 +60,6 @@ variable "nat_ami" {
   }
 }
 
-variable "api_ssl_certificate_id" {
-  description = "SSL Certificate for Tsuru API"
-  default = "arn:aws:iam::988997429095:server-certificate/wildcard_tsuru_paas_alphagov" 
-}
-
 variable "dns_zone_id" {
   description = "Amazon Route53 DNS zone identifier"
   default = "ZAO40KKT7J2PB"

--- a/gce/api-servers.tf
+++ b/gce/api-servers.tf
@@ -27,10 +27,24 @@ resource "google_compute_http_health_check" "api" {
   healthy_threshold = "${var.health_check_healthy}"
   unhealthy_threshold = "${var.health_check_unhealthy}"
 }
+resource "google_compute_http_health_check" "api_https" {
+  name = "${var.env}-tsuru-api-https"
+  port = 443
+  request_path = "/info"
+  check_interval_sec = "${var.health_check_interval}"
+  timeout_sec = "${var.health_check_timeout}"
+  healthy_threshold = "${var.health_check_healthy}"
+  unhealthy_threshold = "${var.health_check_unhealthy}"
+}
 resource "google_compute_target_pool" "api" {
   name = "${var.env}-tsuru-api-lb"
   instances = [ "${google_compute_instance.api.*.self_link}" ]
   health_checks = [ "${google_compute_http_health_check.api.name}" ]
+}
+resource "google_compute_target_pool" "api_https" {
+  name = "${var.env}-tsuru-api-lb-https"
+  instances = [ "${google_compute_instance.api.*.self_link}" ]
+  health_checks = [ "${google_compute_http_health_check.api_https.name}" ]
 }
 resource "google_compute_address" "api" {
   name = "${var.env}-tsuru-api-lb"
@@ -40,4 +54,10 @@ resource "google_compute_forwarding_rule" "api" {
   ip_address = "${google_compute_address.api.address}"
   target = "${google_compute_target_pool.api.self_link}"
   port_range = 8080
+}
+resource "google_compute_forwarding_rule" "api_https" {
+  name = "${var.env}-tsuru-api-lb-https"
+  ip_address = "${google_compute_address.api.address}"
+  target = "${google_compute_target_pool.api_https.self_link}"
+  port_range = 443
 }

--- a/gce/api-servers.tf
+++ b/gce/api-servers.tf
@@ -32,8 +32,12 @@ resource "google_compute_target_pool" "api" {
   instances = [ "${google_compute_instance.api.*.self_link}" ]
   health_checks = [ "${google_compute_http_health_check.api.name}" ]
 }
+resource "google_compute_address" "api" {
+  name = "${var.env}-tsuru-api-lb"
+}
 resource "google_compute_forwarding_rule" "api" {
   name = "${var.env}-tsuru-api-lb"
+  ip_address = "${google_compute_address.api.address}"
   target = "${google_compute_target_pool.api.self_link}"
   port_range = 8080
 }

--- a/gce/api-servers.tf
+++ b/gce/api-servers.tf
@@ -27,24 +27,10 @@ resource "google_compute_http_health_check" "api" {
   healthy_threshold = "${var.health_check_healthy}"
   unhealthy_threshold = "${var.health_check_unhealthy}"
 }
-resource "google_compute_http_health_check" "api_https" {
-  name = "${var.env}-tsuru-api-https"
-  port = 443
-  request_path = "/info"
-  check_interval_sec = "${var.health_check_interval}"
-  timeout_sec = "${var.health_check_timeout}"
-  healthy_threshold = "${var.health_check_healthy}"
-  unhealthy_threshold = "${var.health_check_unhealthy}"
-}
 resource "google_compute_target_pool" "api" {
   name = "${var.env}-tsuru-api-lb"
   instances = [ "${google_compute_instance.api.*.self_link}" ]
   health_checks = [ "${google_compute_http_health_check.api.name}" ]
-}
-resource "google_compute_target_pool" "api_https" {
-  name = "${var.env}-tsuru-api-lb-https"
-  instances = [ "${google_compute_instance.api.*.self_link}" ]
-  health_checks = [ "${google_compute_http_health_check.api_https.name}" ]
 }
 resource "google_compute_address" "api" {
   name = "${var.env}-tsuru-api-lb"
@@ -58,6 +44,6 @@ resource "google_compute_forwarding_rule" "api" {
 resource "google_compute_forwarding_rule" "api_https" {
   name = "${var.env}-tsuru-api-lb-https"
   ip_address = "${google_compute_address.api.address}"
-  target = "${google_compute_target_pool.api_https.self_link}"
+  target = "${google_compute_target_pool.api.self_link}"
   port_range = 443
 }


### PR DESCRIPTION
**What** 
In order to [Use Tsuru API securely](https://www.pivotaltracker.com/n/projects/1275640/stories/93541780) we need to expose, on both AWS and GCE, the port 443 for the `nginx` which terminates SSL (see alphagov/tsuru-ansible#74) for `tsuru-api` servers.

**How to review it**

In this PR:
- On AWS we create the ELB configuration listening on port 443 and forwarding TCP. The health check uses HTTPS:443/info, which tests both `nginx` and `tsuru-api` service.
- On GCE:
  - We explicitly allocate a new ip address, to use it in two different Google compute forwarding rules.
  - we add a second `google_compute_forwarding_rule` for HTTPS/443, but uses the healthcheck in plain HTTP, with HTTP:8080/info. The reason is that the HTTPS check is not supported in terraform and only in the GCE beta API.
- we did NOT delete the old 8080 configuration. This will be done in the next story.

tsuru clients will fail until we deploy a valid certificate, so you can test the SSL termination with curl:

```
curl https://<envname>-api.tsuru2.paas.alphagov.co.uk -k
```

**Who should review this**

@actionjack and @keymon worked on this. @dcarley did the ansible nginx related work.

**Dependencies**
- It is required to merge/use the PR alphagov/tsuru-ansible#74 to deploy nginx for SSL termination
- The certificate is invalid, so the tsuru clients will fail and refuse to connect.
