### PR TITLE
[#95695338] Add HTTPS listener for api in the internal ELB on AWS

### DIFF
--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -46,7 +46,7 @@ resource "aws_elb" "api-int" {
   instances = ["${aws_instance.api.*.id}"]
 
   health_check {
-    target = "HTTP:8080/info"
+    target = "HTTPS:443/info"
     interval = "${var.health_check_interval}"
     timeout = "${var.health_check_timeout}"
     healthy_threshold = "${var.health_check_healthy}"
@@ -57,5 +57,11 @@ resource "aws_elb" "api-int" {
     instance_protocol = "http"
     lb_port = 8080
     lb_protocol = "http"
+  }
+  listener {
+    instance_port = 443
+    instance_protocol = "tcp"
+    lb_port = 443
+    lb_protocol = "tcp"
   }
 }


### PR DESCRIPTION
AWS installation uses a dedicated internal loadbalancer for the api.

We need to add the HTTPS to this ELB so we can allow other services
(i.e gandalf) to communicate securely with the api.
