### PR TITLE
[#96756584] Add graphite server and DNS record

### DIFF
--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -53,3 +53,11 @@ resource "aws_route53_record" "postgresapi" {
   ttl = "60"
   records = ["${aws_elb.router.dns_name}"]
 }
+
+resource "aws_route53_record" "graphite" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-metrics.${var.dns_zone_name}"
+  type = "A"
+  ttl = "60"
+  records = ["${aws_instance.graphite.private_ip}"]
+}

--- a/aws/graphite.tf
+++ b/aws/graphite.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "graphite" {
+  ami = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.private.0.id}"
+  security_groups = ["${aws_security_group.default.id}"]
+  key_name = "${var.key_pair_name}"
+  tags = {
+    Name = "${var.env}-tsuru-graphite"
+  }
+}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -30,6 +30,10 @@ output "postgres.private_ip" {
   value = "${aws_instance.postgres.private_ip}"
 }
 
+output "graphite.private_ip" {
+  value = "${aws_instance.graphite.private_ip}"
+}
+
 output "router.*.ip" {
   value = "${join(",", aws_instance.router.*.private_ip)}"
 }

--- a/gce/dns-records.tf
+++ b/gce/dns-records.tf
@@ -45,3 +45,11 @@ resource "google_dns_record_set" "postgresapi" {
   ttl = "60"
   rrdatas = ["${google_compute_forwarding_rule.router_https.ip_address}"]
 }
+
+resource "google_dns_record_set" "graphite" {
+  managed_zone = "${var.dns_zone_id}"
+  name = "${var.env}-metrics.${var.dns_zone_name}"
+  type = "A"
+  ttl = "60"
+  rrdatas = ["${google_compute_instance.graphite.network_interface.0.address}"]
+}

--- a/gce/graphite.tf
+++ b/gce/graphite.tf
@@ -1,0 +1,19 @@
+resource "google_compute_instance" "graphite" {
+  name = "${var.env}-tsuru-graphite"
+  machine_type = "n1-standard-1"
+  zone = "${element(split(",", var.gce_zones), count.index)}"
+  disk {
+    image = "${var.os_image}"
+  }
+  network_interface {
+    network = "${google_compute_network.network1.name}"
+  }
+  metadata {
+    sshKeys = "${var.user}:${file(\"${var.ssh_key_path}")}"
+  }
+  service_account {
+    scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
+  }
+  tags = [ "private" ]
+}
+

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -30,6 +30,10 @@ output "postgres.private_ip" {
   value = "${google_compute_instance.postgres.network_interface.0.address}"
 }
 
+output "graphite.private_ip" {
+  value = "${google_compute_instance.graphite.network_interface.0.address}"
+}
+
 output "router.*.private_ip" {
   value = "${join(",", google_compute_instance.router.*.network_interface.0.address)}"
 }


### PR DESCRIPTION
Add graphite server and `<env>-metrics.<domain>` DNS record for containers to point to. This is required to collect user metrics from tsuru (see this [story](https://www.pivotaltracker.com/n/projects/1275640/stories/96756584))
