### PR TITLE
[#95695338] Remove HTTP over port 8080 to the API

### DIFF
--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -25,12 +25,6 @@ resource "aws_elb" "api-ext" {
     unhealthy_threshold = "${var.health_check_unhealthy}"
   }
   listener {
-    instance_port = 8080
-    instance_protocol = "http"
-    lb_port = 8080
-    lb_protocol = "http"
-  }
-  listener {
     instance_port = 443
     instance_protocol = "tcp"
     lb_port = 443
@@ -51,12 +45,6 @@ resource "aws_elb" "api-int" {
     timeout = "${var.health_check_timeout}"
     healthy_threshold = "${var.health_check_healthy}"
     unhealthy_threshold = "${var.health_check_unhealthy}"
-  }
-  listener {
-    instance_port = 8080
-    instance_protocol = "http"
-    lb_port = 8080
-    lb_protocol = "http"
   }
   listener {
     instance_port = 443

--- a/gce/api-servers.tf
+++ b/gce/api-servers.tf
@@ -25,12 +25,6 @@ resource "google_compute_target_pool" "api" {
 resource "google_compute_address" "api" {
   name = "${var.env}-tsuru-api-lb"
 }
-resource "google_compute_forwarding_rule" "api" {
-  name = "${var.env}-tsuru-api-lb"
-  ip_address = "${google_compute_address.api.address}"
-  target = "${google_compute_target_pool.api.self_link}"
-  port_range = 8080
-}
 resource "google_compute_forwarding_rule" "api_https" {
   name = "${var.env}-tsuru-api-lb-https"
   ip_address = "${google_compute_address.api.address}"

--- a/gce/api-servers.tf
+++ b/gce/api-servers.tf
@@ -18,19 +18,9 @@ resource "google_compute_instance" "api" {
   tags = [ "private", "web" ]
 }
 
-resource "google_compute_http_health_check" "api" {
-  name = "${var.env}-tsuru-api"
-  port = 8080
-  request_path = "/info"
-  check_interval_sec = "${var.health_check_interval}"
-  timeout_sec = "${var.health_check_timeout}"
-  healthy_threshold = "${var.health_check_healthy}"
-  unhealthy_threshold = "${var.health_check_unhealthy}"
-}
 resource "google_compute_target_pool" "api" {
   name = "${var.env}-tsuru-api-lb"
   instances = [ "${google_compute_instance.api.*.self_link}" ]
-  health_checks = [ "${google_compute_http_health_check.api.name}" ]
 }
 resource "google_compute_address" "api" {
   name = "${var.env}-tsuru-api-lb"

--- a/gce/dns-records.tf
+++ b/gce/dns-records.tf
@@ -11,7 +11,7 @@ resource "google_dns_record_set" "api" {
   name = "${var.env}-api.${var.dns_zone_name}"
   type = "A"
   ttl = "60"
-  rrdatas = ["${google_compute_forwarding_rule.api.ip_address}"]
+  rrdatas = ["${google_compute_address.api.address}"]
 }
 
 resource "google_dns_record_set" "gandalf" {


### PR DESCRIPTION
[Shut down insecure Tsuru API](https://www.pivotaltracker.com/story/show/95695338)

**What**

We are removing insecure access to the `tsuru api` and only allowing access using HTTPS on port 443.

**How this PR should be reviewed**

We have created this PR to be reviewed in the following context:
- I want to change the `tsuru api` load balancer address on `gce` to point to the new resource [google_compute_address.api.address](https://github.com/alphagov/tsuru-terraform/pull/68), we are going to use this instead because we are going to delete `google_compute_forwarding_rule.api.ip_address` in later commit.
- I want to stop the `Amazon Elastic Load Balancers` forwarding any traffic on port `8080` to the `tsuru api servers`
- I want to stop the `Google Compute Load Balancers` running a heathcheck on port `8080` on the `tsuru api servers` but I can not create a healthcheck for port `443` because there is no official support for them under `gce`
- I want to stop the `Google Compute Load Balancers` forwarding any traffic on port `8080` to the `tsuru api servers`

**Who can review this commit**
- Any one in the core team with the exception of @keymon who I paired with :p

**Dependencies**

This **must** be merged after [alphagov/tsuru-ansible Shutdown insecure tsuru](https://github.com/alphagov/tsuru-ansible/pull/86)
