### PR TITLE
[#96173596] Add second docker node to each platform

### DIFF
--- a/aws/docker-servers.tf
+++ b/aws/docker-servers.tf
@@ -1,7 +1,9 @@
 resource "aws_instance" "tsuru-docker" {
+  count = 2
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
-  subnet_id = "${aws_subnet.private.0.id}"
+  subnet_id = "${element(aws_subnet.private.*.id, count.index)}"
+  availability_zone = "${element(aws_subnet.private.*.availability_zone, count.index)}"
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${var.key_pair_name}"
   tags = {

--- a/gce/docker-servers.tf
+++ b/gce/docker-servers.tf
@@ -1,5 +1,6 @@
 resource "google_compute_instance" "docker" {
-  name = "${var.env}-tsuru-docker"
+  count = 2
+  name = "${var.env}-tsuru-docker-${count.index}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {


### PR DESCRIPTION
[Add second docker app node](https://www.pivotaltracker.com/story/show/96173596)

**What**

Create a second docker application node on each platform i.e.
- `Amazon EC2`
- `Google Compute Engine`

**How this PR should be reviewed**

I have created this PR in the following narrative:
- I would like to create a resilient platform and in order to do that I need more than one docker node on each platform therefore I need to create an additional docker node on:
  - `Amazon EC2`
  - `Google Compute Engine`

**Prerequisites**
- [This PR to workaround multichannel ssh intermittently failing needs to be merged in first](https://github.com/alphagov/tsuru-ansible/pull/88)

**Who should review this PR**
- Anyone on the core team with the exception of moi.
