### PR TITLE
aws: Create IAM role for registry on S3

### DIFF
--- a/aws/docker-registry.tf
+++ b/aws/docker-registry.tf
@@ -1,45 +1,50 @@
-resource "aws_iam_role" "docker-registry" {
-  name = "${var.registry_s3_rolename}"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": { "Service": "ec2.amazonaws.com" },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "docker-registry" {
-  name   = "${var.registry_s3_rolename}"
-  role   = "${aws_iam_role.docker-registry.id}"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [ "s3:*" ],
-      "Resource": [
-        "arn:aws:s3:::*-${var.registry_s3_bucketname}",
-        "arn:aws:s3:::*-${var.registry_s3_bucketname}/*"
-      ]
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_instance_profile" "docker-registry" {
-  name  = "${var.registry_s3_rolename}"
-  roles = [ "${aws_iam_role.docker-registry.id}" ]
-}
+#
+# These resources are commented because not all of us have access to create
+# and modify things in IAM. This has been run once by dcarley and remains
+# here for reference or future modification.
+#
+# resource "aws_iam_role" "docker-registry" {
+#   name = "${var.registry_s3_rolename}"
+#   assume_role_policy = <<EOF
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Sid": "",
+#       "Effect": "Allow",
+#       "Principal": { "Service": "ec2.amazonaws.com" },
+#       "Action": "sts:AssumeRole"
+#     }
+#   ]
+# }
+# EOF
+# }
+#
+# resource "aws_iam_role_policy" "docker-registry" {
+#   name   = "${var.registry_s3_rolename}"
+#   role   = "${aws_iam_role.docker-registry.id}"
+#   policy = <<EOF
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Sid": "",
+#       "Effect": "Allow",
+#       "Action": [ "s3:*" ],
+#       "Resource": [
+#         "arn:aws:s3:::*-${var.registry_s3_bucketname}",
+#         "arn:aws:s3:::*-${var.registry_s3_bucketname}/*"
+#       ]
+#     }
+#   ]
+# }
+# EOF
+# }
+#
+# resource "aws_iam_instance_profile" "docker-registry" {
+#   name  = "${var.registry_s3_rolename}"
+#   roles = [ "${aws_iam_role.docker-registry.id}" ]
+# }
 
 resource "aws_instance" "docker-registry" {
   ami = "${lookup(var.amis, var.region)}"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -62,6 +62,11 @@ variable "dns_zone_name" {
   default     = "tsuru.paas.alphagov.co.uk."
 }
 
+variable "registry_s3_rolename" {
+  description = "IAM role name for docker registry on S3"
+  default = "tsuru-docker-registry-s3"
+}
+
 variable "registry_s3_bucketname" {
   description = "S3 Object Storage name for the registry"
   default = "mcp.registry.storage"  


### PR DESCRIPTION
#### aws: Create IAM role for registry on S3

Create an IAM role and instance profile, associated with the registry
instance, which will allow it to access S3 without using a predefined
access/secret key.

The policy matches what we had previously setup by hand for the single
username/keypair. It will allow access to the buckets of all independent
environments. It's not possible to restrict this further without giving
everyone access to IAM.

NB: The `iam_instance_profile` attribute is `ForceNew` so the registry
instance will be recreated. This is OK though, because the data is in S3 and
the index will be rebuilt from S3 when the new machine comes up.
#### aws: Comment out IAM role resources

Per the comment:

> These resources are commented because not all of us have access to create
> and modify things in IAM. This has been run once by dcarley and remain
> here for reference or future modification.

Using `#` comments instead of `/* */` because hashicorp/terraform#2248
results in the following error:

```
➜  aws git:(docker_registry_s3_role) ✗ terraform apply -var env=dcarley
Error configuring: 2 error(s) occurred:

* aws_route53_record.docker-registry: missing dependency: aws_instance.docker-registry
* output.docker-registry.private_ip: missing dependency: aws_instance.docker-registry
```
