### PR TITLE
Force destroy buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,36 @@ The terraform provider for AWS will read the standard AWS credentials environmen
 
 You can get the credentials from the AWS console.
 
+### Provision the environment
+
+In order to provision a test environment:
+
+ 1. Go to the desired platform directory:  `cd aws` or `cd gce`
+ 2. run `terraform apply -var env=<env-name-prefix> -var force_destroy=true`
+
+**IMPORTANT**: The option `-var force_destroy=true` will mark all the resources,
+including datastores, to be deleted when destroying the environment.
+This is OK in test environment, but dangerous in production ones.
+
 ### Destroy
 
-When you destroy the infrastructure, you will get an error if you try to delete a non empty GCS or S3 bucket.
-To force the destruction of the bucket content:
+When you destroy the infrastructure, you will get an error if you try to
+delete a non empty GCS or S3 bucket if the option `force_destroy=true` was
+not initially set.
+
+To force the destruction of the bucket content you need to reapply terraform
+to update the state (file `terraform.tfstate`). Limit the scope of apply to
+the bucket with `-target` to avoid recreating all the other resources:
+
 ```bash
-$ terraform destroy -var env="my_env" -var force_destroy=true
+# On AWS:
+terraform apply -var env=<env-name-prefix> -var force_destroy=true -target=aws_s3_bucket.registry-s3
+terraform destroy -var env=<env-name-prefix> -var force_destroy=true
+# On GCE:
+terraform apply -var env=<env-name-prefix> -var force_destroy=true -target=google_storage_bucket.registry-gcs
+terraform destroy -var env=<env-name-prefix> -var force_destroy=true
+
 ```
-You may have to reapply with this option before destroying.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ The terraform provider for AWS will read the standard AWS credentials environmen
 
 You can get the credentials from the AWS console.
 
+### Destroy
+
+When you destroy the infrastructure, you will get an error if you try to delete a non empty GCS or S3 bucket.
+To force the destruction of the bucket content:
+```bash
+$ terraform destroy -var env="my_env" -var force_destroy=true
+```
+You may have to reapply with this option before destroying.
+
 ## Notes
 
 Change into one of the provider sub-directories before executing `terraform` commands.

--- a/aws/docker-registry.tf
+++ b/aws/docker-registry.tf
@@ -65,5 +65,6 @@ resource "aws_instance" "docker-registry" {
 resource "aws_s3_bucket" "registry-s3" {
     bucket = "${var.env}-${var.registry_s3_bucketname}"
     acl = "private"
+    force_destroy = "${var.force_destroy}"
 }
 

--- a/gce/docker-registry.tf
+++ b/gce/docker-registry.tf
@@ -22,4 +22,5 @@ resource "google_storage_bucket" "registry-gcs" {
     name = "${var.env}-${var.registry_gcs_bucketname}"
     predefined_acl = "${var.registry_gcs_bucketname_acl}"
     location = "${var.gcs_region}"
+    force_destroy = "${var.force_destroy}"
 }

--- a/globals.tf
+++ b/globals.tf
@@ -27,3 +27,8 @@ variable "health_check_unhealthy" {
   description = "Threshold to consider load balancer unhealthy"
   default     = 2
 }
+
+variable "force_destroy" {
+  description = "Delete GCS and S3 buckets content"
+  default     = false
+}


### PR DESCRIPTION
This PR allows deleting the content of S3 and GCE buckets on a terraform destroy action.
This is really useful when using test environments. It may be dangerous for production, but if one uses _destroy_ on a production environment we would probably have bigger problems anyway.

**How to review**
_terraform destroy_ on GCE and AWS should delete everything, including storage.

**Note**
If the environment was created _before_ this update, you may have to apply it again before using destroy.
