### PR TITLE
Resources for Postgres log shipping

### DIFF
--- a/aws/postgres-server.tf
+++ b/aws/postgres-server.tf
@@ -1,10 +1,61 @@
+resource "aws_iam_role" "postgres" {
+  name = "${var.postgres_s3_rolename}"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": { "Service": "ec2.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "postgres" {
+  name   = "${var.postgres_s3_rolename}"
+  role   = "${aws_iam_role.postgres.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [ "s3:*" ],
+      "Resource": [
+        "arn:aws:s3:::*-${var.postgres_s3_bucketname}",
+        "arn:aws:s3:::*-${var.postgres_s3_bucketname}/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "postgres" {
+  name  = "${var.postgres_s3_rolename}"
+  roles = [ "${aws_iam_role.postgres.id}" ]
+}
+
 resource "aws_instance" "postgres" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.private.0.id}"
   security_groups = ["${aws_security_group.default.id}"]
+  iam_instance_profile = "${var.postgres_s3_rolename}"
   key_name = "${var.key_pair_name}"
   tags = {
     Name = "${var.env}-tsuru-postgres"
   }
 }
+
+resource "aws_s3_bucket" "postgres-s3" {
+    bucket = "${var.env}-${var.postgres_s3_bucketname}"
+    acl = "private"
+    force_destroy = "${var.force_destroy}"
+}
+

--- a/aws/postgres-server.tf
+++ b/aws/postgres-server.tf
@@ -1,45 +1,49 @@
-resource "aws_iam_role" "postgres" {
-  name = "${var.postgres_s3_rolename}"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": { "Service": "ec2.amazonaws.com" },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "postgres" {
-  name   = "${var.postgres_s3_rolename}"
-  role   = "${aws_iam_role.postgres.id}"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [ "s3:*" ],
-      "Resource": [
-        "arn:aws:s3:::*-${var.postgres_s3_bucketname}",
-        "arn:aws:s3:::*-${var.postgres_s3_bucketname}/*"
-      ]
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_instance_profile" "postgres" {
-  name  = "${var.postgres_s3_rolename}"
-  roles = [ "${aws_iam_role.postgres.id}" ]
-}
+#
+# These resources are commented out because not everyone has permissions
+# necessary to create them.
+#
+#resource "aws_iam_role" "postgres" {
+#  name = "${var.postgres_s3_rolename}"
+#  assume_role_policy = <<EOF
+#{
+#  "Version": "2012-10-17",
+#  "Statement": [
+#    {
+#      "Sid": "",
+#      "Effect": "Allow",
+#      "Principal": { "Service": "ec2.amazonaws.com" },
+#      "Action": "sts:AssumeRole"
+#    }
+#  ]
+#}
+#EOF
+#}
+#
+#resource "aws_iam_role_policy" "postgres" {
+#  name   = "${var.postgres_s3_rolename}"
+#  role   = "${aws_iam_role.postgres.id}"
+#  policy = <<EOF
+#{
+#  "Version": "2012-10-17",
+#  "Statement": [
+#    {
+#      "Sid": "",
+#      "Effect": "Allow",
+#      "Action": [ "s3:*" ],
+#      "Resource": [
+#        "arn:aws:s3:::*-${var.postgres_s3_bucketname}",
+#        "arn:aws:s3:::*-${var.postgres_s3_bucketname}/*"
+#      ]
+#    }
+#  ]
+#}
+#EOF
+#}
+#
+#resource "aws_iam_instance_profile" "postgres" {
+#  name  = "${var.postgres_s3_rolename}"
+#  roles = [ "${aws_iam_role.postgres.id}" ]
+#}
 
 resource "aws_instance" "postgres" {
   ami = "${lookup(var.amis, var.region)}"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -69,7 +69,17 @@ variable "registry_s3_rolename" {
 
 variable "registry_s3_bucketname" {
   description = "S3 Object Storage name for the registry"
-  default = "mcp.registry.storage"  
+  default = "mcp.registry.storage"
+}
+
+variable "postgres_s3_bucketname" {
+  description = "S3 Object Storage name for postgres"
+  default = "mcp.postgres.backup"
+}
+
+variable "postgres_s3_rolename" {
+  description = "IAM role name for postgres on S3"
+  default = "postgres-s3"
 }
 
 variable "key_pair_name" {


### PR DESCRIPTION
Create the S3 bucket necessary for Postgres write-ahead log backups, and grant access to the Postgres machine using an instance IAM role for authentication. 

This is nearly identical to what was done for the docker registry in #74, and is similarly hard to test because my IAM role doesn't have the appropriate permissions.
