### PR TITLE
[#98365398] Added creation of a Google Storage bucket for Postgres backups

### DIFF
--- a/gce/postgres-server.tf
+++ b/gce/postgres-server.tf
@@ -17,3 +17,8 @@ resource "google_compute_instance" "postgres" {
   tags = [ "private" ]
 }
 
+resource "google_storage_bucket" "postgres-gs" {
+    name = "${var.env}-${var.postgres_gs_bucketname}"
+    predefined_acl = "projectPrivate"
+    location = "EU"
+}

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -66,3 +66,8 @@ variable "registry_gcs_bucketname_acl" {
   description = "GCS Bucket canned Access Control List"
   default = "projectPrivate"
 }
+
+variable "postgres_gs_bucketname" {
+  description = "GCS Object Storage name for postgres"
+  default = "mcp-postgres-backup"
+}


### PR DESCRIPTION
This PR adds a Google Storage bucket which will be used for Postgres backups.
# Who should review

Anyone but @RichardKnop
# How to review
-  Have a GCE environment ready
-  Checkout this branch
-  Run `terraform plan -var 'env=myenvironment'`
  
  You should see that Terraform notices once change:
  
  ```
  + google_storage_bucket.postgres-gs
  force_destroy:  "" => "0"
  location:       "" => "EU"
  name:           "" => "myenvironment-mcp-postgres-backup"
  predefined_acl: "" => "projectPrivate"
  ```
  
  You can also then apply terraform changes and check GS console to make sure the bucket has been created.
