### PR TITLE
[#98109110] Make AWS NAT server run on ubuntu

### DIFF
--- a/aws/nat-server.tf
+++ b/aws/nat-server.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "nat" {
-  ami = "${lookup(var.nat_ami, var.region)}"
+  ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public.0.id}"
   security_groups = ["${aws_security_group.default.id}", "${aws_security_group.nat.id}"]
@@ -9,16 +9,17 @@ resource "aws_instance" "nat" {
     Name = "${var.env}-tsuru-nat"
   }
   connection {
-    user = "ec2-user"
+    user = "ubuntu"
     key_file = "ssh/insecure-deployer"
   }
   provisioner "remote-exec" {
     inline = [
-      "yum update -y aws*",
       "echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward",
       "echo 0 | sudo tee /proc/sys/net/ipv4/conf/eth0/send_redirects",
+      "sudo apt-get update -qq",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq iptables-persistent",
       "sudo iptables -t nat -A POSTROUTING -o eth0 -s 0.0.0.0/0 -j MASQUERADE",
-      "sudo iptables-save | sudo tee /etc/sysconfig/iptables",
+      "sudo service iptables-persistent save",
       "sudo mkdir -p /etc/sysctl.d/",
       "echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/nat.conf",
       "echo 'net.ipv4.conf.eth0.send_redirects = 0' | sudo tee -a /etc/sysctl.d/nat.conf"

--- a/aws/nat-server.tf
+++ b/aws/nat-server.tf
@@ -5,7 +5,7 @@ resource "aws_instance" "nat" {
   security_groups = ["${aws_security_group.default.id}", "${aws_security_group.nat.id}"]
   key_name = "${var.key_pair_name}"
   source_dest_check = false
-  tags = { 
+  tags = {
     Name = "${var.env}-tsuru-nat"
   }
   connection {
@@ -13,16 +13,6 @@ resource "aws_instance" "nat" {
     key_file = "ssh/insecure-deployer"
   }
   provisioner "remote-exec" {
-    inline = [
-      "echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward",
-      "echo 0 | sudo tee /proc/sys/net/ipv4/conf/eth0/send_redirects",
-      "sudo apt-get update -qq",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq iptables-persistent",
-      "sudo iptables -t nat -A POSTROUTING -o eth0 -s 0.0.0.0/0 -j MASQUERADE",
-      "sudo service iptables-persistent save",
-      "sudo mkdir -p /etc/sysctl.d/",
-      "echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/nat.conf",
-      "echo 'net.ipv4.conf.eth0.send_redirects = 0' | sudo tee -a /etc/sysctl.d/nat.conf"
-    ]
+    script = "../setup-nat-routing.sh"
   }
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -44,14 +44,6 @@ variable "amis" {
   }
 }
 
-variable "nat_ami" {
-  description = "Base AMI to launch the NAT instance with"
-  default = {
-    eu-west-1 = "ami-14913f63"
-    eu-central-1 = "ami-a8221fb5"
-  }
-}
-
 variable "dns_zone_id" {
   description = "Amazon Route53 DNS zone identifier"
   default = "ZAO40KKT7J2PB"

--- a/gce/nat-server.tf
+++ b/gce/nat-server.tf
@@ -23,17 +23,7 @@ resource "google_compute_instance" "nat" {
     key_file = "ssh/insecure-deployer"
   }
   provisioner "remote-exec" {
-    inline = [
-      "echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward",
-      "echo 0 | sudo tee /proc/sys/net/ipv4/conf/eth0/send_redirects",
-      "sudo apt-get update -qq",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq iptables-persistent",
-      "sudo iptables -t nat -A POSTROUTING -o eth0 -s 0.0.0.0/0 -j MASQUERADE",
-      "sudo service iptables-persistent save",
-      "sudo mkdir -p /etc/sysctl.d/",
-      "echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/nat.conf",
-      "echo 'net.ipv4.conf.eth0.send_redirects = 0' | sudo tee -a /etc/sysctl.d/nat.conf"
-    ]
+    script = "../setup-nat-routing.sh"
   }
   tags = [ "public", "nat" ]
 }

--- a/setup-nat-routing.sh
+++ b/setup-nat-routing.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward
+echo 0 | sudo tee /proc/sys/net/ipv4/conf/eth0/send_redirects
+sudo apt-get update -qq
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq iptables-persistent
+sudo iptables -t nat -A POSTROUTING -o eth0 -s 0.0.0.0/0 -j MASQUERADE
+sudo service iptables-persistent save
+sudo mkdir -p /etc/sysctl.d/
+echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/nat.conf
+echo 'net.ipv4.conf.eth0.send_redirects = 0' | sudo tee -a /etc/sysctl.d/nat.conf
+

--- a/setup-nat-routing.sh
+++ b/setup-nat-routing.sh
@@ -4,11 +4,17 @@ set -e
 
 echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward
 echo 0 | sudo tee /proc/sys/net/ipv4/conf/eth0/send_redirects
-sudo apt-get update -qq
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq iptables-persistent
-sudo iptables -t nat -A POSTROUTING -o eth0 -s 0.0.0.0/0 -j MASQUERADE
-sudo service iptables-persistent save
 sudo mkdir -p /etc/sysctl.d/
 echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/nat.conf
 echo 'net.ipv4.conf.eth0.send_redirects = 0' | sudo tee -a /etc/sysctl.d/nat.conf
+
+sudo iptables -t nat -A POSTROUTING -o eth0 -s 0.0.0.0/0 -j MASQUERADE
+
+# Cloudinit changes the package repositories, which can make fail next steps.
+# Let's wait for it to finish.
+while pgrep cloud-init > /dev/null; do echo "Waiting for cloudinit to finish..."; sleep 1; done
+
+sudo apt-get update -qq
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y iptables-persistent
+sudo service iptables-persistent save
 

--- a/setup-nat-routing.sh
+++ b/setup-nat-routing.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
 
+# Redirect stdout ( > ) into a log file.
+exec > /tmp/setup-nat-routing.log
+exec 2>&1
+
 set -e
 
+echo "NAT: Enabling routing features in the kernel"
 echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward
 echo 0 | sudo tee /proc/sys/net/ipv4/conf/eth0/send_redirects
 sudo mkdir -p /etc/sysctl.d/
 echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/nat.conf
 echo 'net.ipv4.conf.eth0.send_redirects = 0' | sudo tee -a /etc/sysctl.d/nat.conf
 
+echo "NAT: Setting up NAT-MASQUERADE"
 sudo iptables -t nat -A POSTROUTING -o eth0 -s 0.0.0.0/0 -j MASQUERADE
 
 # Cloudinit changes the package repositories, which can make fail next steps.
 # Let's wait for it to finish.
 while pgrep cloud-init > /dev/null; do echo "Waiting for cloudinit to finish..."; sleep 1; done
 
-sudo apt-get update -qq
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y iptables-persistent
+echo "Save iptables state"
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
 sudo service iptables-persistent save
 


### PR DESCRIPTION
Make the AWS NAT server run using ubuntu, just like the GCE NAT and all other hosts.

This is needed for shutdown scripts. Otherwise there's problem running ansible against the NAT box itself, as it can't ssh to itself, because it's using different user name than all the hosts.

Additionally, we found a problem in the NAT server which prevents it from setting up NAT routing after reboot, as it was not installing a package to persist the iptables state.

After this is merged, ssh config template needs updating: https://github.com/alphagov/tsuru-ansible/pull/113
