### PR TITLE
[#98091344] Add metrics capture to core components

### DIFF
--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -53,3 +53,13 @@ resource "aws_route53_record" "postgresapi" {
   ttl = "60"
   records = ["${aws_elb.router.dns_name}"]
 }
+
+resource "aws_route53_record" "grafana" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-grafana.${var.dns_zone_name}"
+  type = "A"
+  ttl = "60"
+  records = ["${aws_instance.influx-grafana.public_ip}"]
+}
+
+

--- a/aws/influx.tf
+++ b/aws/influx.tf
@@ -3,7 +3,7 @@ resource "aws_instance" "influx-grafana" {
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.public.0.id}"
   associate_public_ip_address = true
-  security_groups = ["${aws_security_group.default.id}", "${aws_security_group.web.id}"]
+  security_groups = ["${aws_security_group.default.id}", "${aws_security_group.grafana.id}"]
   key_name = "${var.key_pair_name}"
   tags = {
     Name = "${var.env}-influx-grafana"

--- a/aws/influx.tf
+++ b/aws/influx.tf
@@ -1,7 +1,8 @@
 resource "aws_instance" "influx-grafana" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.medium"
-  subnet_id = "${aws_subnet.private.0.id}"
+  subnet_id = "${aws_subnet.public.0.id}"
+  associate_public_ip_address = true
   security_groups = ["${aws_security_group.default.id}", "${aws_security_group.web.id}"]
   key_name = "${var.key_pair_name}"
   tags = {

--- a/aws/influx.tf
+++ b/aws/influx.tf
@@ -1,0 +1,11 @@
+resource "aws_instance" "influx-grafana" {
+  ami = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.medium"
+  subnet_id = "${aws_subnet.private.0.id}"
+  security_groups = ["${aws_security_group.default.id}", "${aws_security_group.web.id}"]
+  key_name = "${var.key_pair_name}"
+  tags = {
+    Name = "${var.env}-influx-grafana"
+  }
+}
+

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -22,6 +22,14 @@ output "gandalf.public.ip" {
   value = "${aws_instance.gandalf.public_ip}"
 }
 
+output "influx-grafana.private.ip" {
+  value = "${aws_instance.influx-grafana.private_ip}"
+}
+
+output "influx-grafana.public.ip" {
+  value = "${aws_instance.influx-grafana.public_ip}"
+}
+
 output "nat.ip" {
   value = "${aws_instance.nat.public_ip}"
 }

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -103,6 +103,23 @@ resource "aws_security_group" "web" {
     cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
   }
 
+  tags {
+    Name = "${var.env}-tsuru-web"
+  }
+}
+
+resource "aws_security_group" "grafana" {
+  name = "${var.env}-grafana-tsuru"
+  description = "Security group for grafana that allows traffic from the office"
+  vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   ingress {
     from_port = 3000
     to_port   = 3000
@@ -118,7 +135,7 @@ resource "aws_security_group" "web" {
   }
 
   tags {
-    Name = "${var.env}-tsuru-web"
+    Name = "${var.env}-influx-grafana"
   }
 }
 

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -103,6 +103,20 @@ resource "aws_security_group" "web" {
     cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
   }
 
+  ingress {
+    from_port = 3000
+    to_port   = 3000
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
+  }
+
+  ingress {
+    from_port = 8083
+    to_port   = 8083
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
+  }
+
   tags {
     Name = "${var.env}-tsuru-web"
   }

--- a/gce/dns-records.tf
+++ b/gce/dns-records.tf
@@ -45,3 +45,11 @@ resource "google_dns_record_set" "postgresapi" {
   ttl = "60"
   rrdatas = ["${google_compute_forwarding_rule.router_https.ip_address}"]
 }
+resource "google_dns_record_set" "grafana" {
+  managed_zone = "${var.dns_zone_id}"
+  name = "${var.env}-grafana.${var.dns_zone_name}"
+  type = "A"
+  ttl = "60"
+  rrdatas = ["${google_compute_instance.influx-grafana.network_interface.0.access_config.0.nat_ip}"]
+}
+

--- a/gce/influx.tf
+++ b/gce/influx.tf
@@ -8,6 +8,7 @@ resource "google_compute_instance" "influx-grafana" {
   }
   network_interface {
     network = "${google_compute_network.network1.name}"
+    access_config {}
   }
   metadata {
     sshKeys = "${var.user}:${file(\"${var.ssh_key_path}")}"
@@ -15,6 +16,6 @@ resource "google_compute_instance" "influx-grafana" {
   service_account {
     scopes = [ "compute-ro", "storage-rw", "userinfo-email" ]
   }
-  tags = [ "private" ]
+  tags = [ "public", "web" ]
 }
 

--- a/gce/influx.tf
+++ b/gce/influx.tf
@@ -16,6 +16,6 @@ resource "google_compute_instance" "influx-grafana" {
   service_account {
     scopes = [ "compute-ro", "storage-rw", "userinfo-email" ]
   }
-  tags = [ "public", "web" ]
+  tags = [ "public", "grafana" ]
 }
 

--- a/gce/influx.tf
+++ b/gce/influx.tf
@@ -1,0 +1,20 @@
+resource "google_compute_instance" "influx-grafana" {
+  name = "${var.env}-influx-grafana"
+  machine_type = "n1-standard-1"
+  zone = "${element(split(",", var.gce_zones), count.index)}"
+  disk {
+    image = "${var.os_image}"
+    size = 100
+  }
+  network_interface {
+    network = "${google_compute_network.network1.name}"
+  }
+  metadata {
+    sshKeys = "${var.user}:${file(\"${var.ssh_key_path}")}"
+  }
+  service_account {
+    scopes = [ "compute-ro", "storage-rw", "userinfo-email" ]
+  }
+  tags = [ "private" ]
+}
+

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -22,6 +22,14 @@ output "gandalf.public.ip" {
   value = "${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}"
 }
 
+output "influx.private_ip" {
+  value = "${google_compute_instance.influx-grafana.network_interface.0.address}"
+}
+
+output "influx.public.ip" {
+  value = "${google_compute_instance.influx-grafana.network_interface.0.access_config.0.nat_ip}"
+}
+
 output "nat.ip" {
   value = "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}"
 }

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -54,6 +54,6 @@ resource "google_compute_firewall" "web" {
 
   allow {
     protocol = "tcp"
-    ports = [ 80, 8080, 443 ]
+    ports = [ 80, 8080, 443, 3000, 8083 ]
   }
 }

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -54,6 +54,25 @@ resource "google_compute_firewall" "web" {
 
   allow {
     protocol = "tcp"
-    ports = [ 80, 8080, 443, 3000, 8083 ]
+    ports = [ 80, 8080, 443 ]
   }
 }
+resource "google_compute_firewall" "grafana" {
+  name = "${var.env}-grafana-tsuru"
+  description = "Security group for grafana that allows traffic from the office"
+  network = "${google_compute_network.network1.name}"
+
+  source_ranges = [
+    "${split(",", var.office_cidrs)}","${var.jenkins_elastic}",
+    "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}",
+    "${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}",
+    "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}/32",
+  ]
+  target_tags = [ "grafana" ]
+
+  allow {
+    protocol = "tcp"
+    ports = [ 3000, 8083 ]
+  }
+}
+


### PR DESCRIPTION
**What**

We wish to have platform statistics logged into a time-series database backend database where they can later be collected and graphed using Grafana

In order to facillitate this, the terraform manifests need to be modified to:
- deploy an additional VM for influxdb & grafana to reside upon
- Add a DNS record for a friendly URL for the grafana dashboard
- Open TCP/3000 and TCP/8083 for access to grafana and influxdb GUIs respectively
- Display the public and private IP addresses for the influx_grafana VM in the terraform output

**How to review this PR**

I've created the PR to be reviewed in the following context:
- I need an additional VM and DNS record to be deployed using terraform which can later be configured using ansible.

**Who should review this PR**
- Anyone in the core team except for @actionjack because he worked on this with me.
