### PR TITLE
[#95168192] Unify AWS and GCE node names

### DIFF
--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -7,7 +7,7 @@ resource "aws_instance" "api" {
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${var.key_pair_name}"
   tags = {
-    Name = "${var.env}-tsuru-api"
+    Name = "${var.env}-tsuru-api-${count.index}"
   }
 }
 

--- a/aws/docker-servers.tf
+++ b/aws/docker-servers.tf
@@ -7,7 +7,7 @@ resource "aws_instance" "tsuru-docker" {
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${var.key_pair_name}"
   tags = {
-    Name = "${var.env}-tsuru-docker"
+    Name = "${var.env}-tsuru-docker-${count.index}"
   }
 }
 

--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -7,7 +7,7 @@ resource "aws_instance" "router" {
   security_groups = ["${aws_security_group.default.id}"]
   key_name = "${var.key_pair_name}"
   tags = {
-    Name = "${var.env}-tsuru-router"
+    Name = "${var.env}-tsuru-router-${count.index}"
   }
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,7 +1,3 @@
-variable "env" {
-  description = "Environment name"
-}
-
 variable "region"     {
   description = "AWS region"
   default     = "eu-west-1"

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -23,10 +23,6 @@ variable "gce_zones" {
   default = "europe-west1-b,europe-west1-c,europe-west1-d"
 }
 
-variable "env" {
-  description = "Environment name"
-}
-
 variable "ssh_key_path" {
   description = "Path to the ssh key to use"
   default = "ssh/insecure-deployer.pub"

--- a/globals.tf
+++ b/globals.tf
@@ -1,3 +1,7 @@
+variable "env" {
+  description = "Environment name"
+}
+
 variable "office_cidrs" {
   description = "CSV of CIDR addresses for our office which will be trusted"
   default     = "80.194.77.90/32,80.194.77.100/32"


### PR DESCRIPTION
There is no reason why we should have different node names between AWS and GCE. Having same node names makes our ansible and terraform configuration more clear and straightforward.
