### PR TITLE
[#98271560] Add missing terraform outputs

### DIFF
--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -6,8 +6,8 @@ output "tsuru-db.ip" {
   value = "${aws_instance.tsuru-db.private_ip}"
 }
 
-output "docker.private.ip" {
-  value = "${aws_instance.tsuru-docker.private_ip}"
+output "tsuru-docker.*.private.ip" {
+  value = "${join(",", aws_instance.tsuru-docker.*.private_ip)}"
 }
 
 output "docker-registry.private_ip" {

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -34,8 +34,8 @@ output "nat.ip" {
   value = "${aws_instance.nat.public_ip}"
 }
 
-output "postgres.private_ip" {
-  value = "${aws_instance.postgres.private_ip}"
+output "postgres.*.private_ip" {
+  value = "${join(",", aws_instance.postgres.*.private_ip)}"
 }
 
 output "router.*.ip" {

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -6,8 +6,8 @@ output "db.private_ip" {
   value = "${google_compute_instance.db.network_interface.0.address}"
 }
 
-output "docker.private_ip" {
-  value = "${google_compute_instance.docker.network_interface.0.address}"
+output "docker.*.private_ip" {
+  value = "${join(",", google_compute_instance.docker.*.network_interface.0.address)}"
 }
 
 output "docker-registry.private_ip" {

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -34,8 +34,8 @@ output "nat.ip" {
   value = "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}"
 }
 
-output "postgres.private_ip" {
-  value = "${google_compute_instance.postgres.network_interface.0.address}"
+output "postgres.*.private_ip" {
+  value = "${join(",", google_compute_instance.postgres.*.network_interface.0.address)}"
 }
 
 output "router.*.private_ip" {


### PR DESCRIPTION
When we were adding second postgresql server, the terraform outputs stopped working, due to internal terraform instance naming/ID changing (from postgresql to postgresql.n). Fix this.

Same issue was notified with docker servers. This has probably happened when second docker node was added. Fix docker output as well.
