### PR TITLE
[#98453390] Remove internal LB

### DIFF
--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -31,25 +31,3 @@ resource "aws_elb" "api-ext" {
     lb_protocol = "tcp"
   }
 }
-
-resource "aws_elb" "api-int" {
-  name = "${var.env}-tsuru-api-elb-int"
-  subnets = ["${aws_subnet.private.*.id}"]
-  internal = true
-  security_groups = ["${aws_security_group.default.id}", "${aws_security_group.web.id}"]
-  instances = ["${aws_instance.api.*.id}"]
-
-  health_check {
-    target = "HTTPS:443/info"
-    interval = "${var.health_check_interval}"
-    timeout = "${var.health_check_timeout}"
-    healthy_threshold = "${var.health_check_healthy}"
-    unhealthy_threshold = "${var.health_check_unhealthy}"
-  }
-  listener {
-    instance_port = 443
-    instance_protocol = "tcp"
-    lb_port = 443
-    lb_protocol = "tcp"
-  }
-}

--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -14,14 +14,6 @@ resource "aws_route53_record" "api-external" {
   records = ["${aws_elb.api-ext.dns_name}"]
 }
 
-resource "aws_route53_record" "api-internal" {
-  zone_id = "${var.dns_zone_id}"
-  name = "${var.env}-api-int.${var.dns_zone_name}"
-  type = "CNAME"
-  ttl = "60"
-  records = ["${aws_elb.api-int.dns_name}"]
-}
-
 resource "aws_route53_record" "gandalf" {
   zone_id = "${var.dns_zone_id}"
   name = "${var.env}-gandalf.${var.dns_zone_name}"

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -139,17 +139,3 @@ resource "aws_security_group" "grafana" {
     Name = "${var.env}-influx-grafana"
   }
 }
-
-/* FIXME: Unused, remove when deployed to CI */
-resource "aws_security_group" "web-int" {
-  name = "${var.env}-web-int-tsuru"
-  description = "Security group for web that allows web traffic from internet"
-  vpc_id = "${aws_vpc.default.id}"
-}
-
-/* FIXME: Unused, remove when deployed to CI */
-resource "aws_security_group" "sslproxy" {
-  name = "${var.env}-tsuru-sslproxy"
-  description = "Security group for sslproxy/offloader feedind the tsuru router elb"
-  vpc_id = "${aws_vpc.default.id}"
-}

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -100,7 +100,8 @@ resource "aws_security_group" "web" {
     from_port = 443
     to_port   = 443
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32",
+                   "${aws_instance.gandalf.public_ip}/32"]
   }
 
   tags {

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -49,6 +49,7 @@ resource "google_compute_firewall" "web" {
     "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}",
     "${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}",
     "${google_compute_instance.nat.network_interface.0.access_config.0.nat_ip}/32",
+     "${google_compute_instance.gandalf.network_interface.0.access_config.0.nat_ip}/32",
   ]
   target_tags = [ "web" ]
 

--- a/gce/ssl-proxies.tf
+++ b/gce/ssl-proxies.tf
@@ -1,6 +1,0 @@
-/* FIXME: Unused, remove when deployed to CI */
-resource "google_compute_target_pool" "tsuru-sslproxy" {
-  name = "${var.env}-tsuru-sslproxy-lb"
-  instances = []
-  health_checks = []
-}


### PR DESCRIPTION
Remove internal LB from AWS. Internal LB on aws is only being used by Gandalf to connect to the tsuru API for callbacks. It seems internal LB was left as leftover from time when we had separate SSL proxies and routers/API and LBs between them. Given that Gandalf can talk to the Tsuru API directly on the external URL (and do so securely - via SSL & limited by firewall to specific gandalf IP), there's no need to keep running internal LB anymore. On GCE, there's no internal LB. There is a [story](https://www.pivotaltracker.com/n/projects/1275640/stories/93542284) to add it, but it seems that story is from time when we had SSL proxies and having parity between AWS and GCE meant adding internal LB to GCE.
### Testing:
1. Apply this PR
2. Apply [ansible PR](https://github.com/alphagov/tsuru-ansible/pull/132)
3. run smoketests `make test-aws DEPLOY_ENV=...` and `make test-gce DEPLOY_ENV=...`
