### PR TITLE
[#98824506] Add DNS record for postgres master

### DIFF
--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -46,6 +46,14 @@ resource "aws_route53_record" "docker-registry" {
   records = ["${aws_instance.docker-registry.private_ip}"]
 }
 
+resource "aws_route53_record" "postgres-master" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-postgres-master.${var.dns_zone_name}"
+  type = "A"
+  ttl = "60"
+  records = ["${aws_instance.postgres.0.private_ip}"]
+}
+
 resource "aws_route53_record" "postgresapi" {
   zone_id = "${var.dns_zone_id}"
   name = "${var.env}-postgresapi.${var.dns_zone_name}"

--- a/gce/dns-records.tf
+++ b/gce/dns-records.tf
@@ -38,6 +38,14 @@ resource "google_dns_record_set" "docker-registry" {
   rrdatas = ["${google_compute_instance.docker-registry.network_interface.0.address}"]
 }
 
+resource "google_dns_record_set" "postgres-master" {
+  managed_zone = "${var.dns_zone_id}"
+  name = "${var.env}-postgres-master.${var.dns_zone_name}"
+  type = "A"
+  ttl = "60"
+  rrdatas = ["${google_compute_instance.postgres.0.network_interface.0.address}"]
+}
+
 resource "google_dns_record_set" "postgresapi" {
   managed_zone = "${var.dns_zone_id}"
   name = "${var.env}-postgresapi.${var.dns_zone_name}"


### PR DESCRIPTION
[Restore postgres to a different IP](https://www.pivotaltracker.com/story/show/98824506)

**What**

We may need to restore a postgres database to a different host with a different IP address. This means we will need to repoint the postgres server instance to the new IP address and ensure that any apps consuming the database are still working correctly.
- Given a platform running an application with a postgres database
- When the postgres database is restored to a different IP address
- Then the applications using the database continue to function
- And they are able to read and write data to the newly restored database

We feel the easiest way to achieve this is to use a DNS entry for the primary PostgreSQL master and figure out a way later to handle recovery.

**How to Review this PR**

This PR should be reviewed in the following context:
- I want to create a DNS record for the postgres master on each platform

**How to test this PR**

Use `terraform apply -var=YOUR_ENVIRONMENT_NAME` on each platform (AWS/GCE)

Check either the output of terraform or the cloud platform console for the creation of the `ENV_NAME-postgres-master` DNS record.

**Who should review this PR**
- Any one in the team except @saliceti who I paired with
