### PR TITLE
[#99121602] Add elasticsearch server

### DIFF
--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -70,4 +70,10 @@ resource "aws_route53_record" "grafana" {
   records = ["${aws_instance.influx-grafana.public_ip}"]
 }
 
-
+resource "aws_route53_record" "elasticsearchapi" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-elasticsearchapi.${var.dns_zone_name}"
+  type = "CNAME"
+  ttl = "60"
+  records = ["${aws_elb.router.dns_name}"]
+}

--- a/aws/elasticsearch.tf
+++ b/aws/elasticsearch.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "elasticsearch" {
+  ami = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.private.0.id}"
+  security_groups = ["${aws_security_group.default.id}"]
+  key_name = "${var.key_pair_name}"
+  tags = {
+    Name = "${var.env}-tsuru-elasticsearch"
+  }
+}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -38,6 +38,10 @@ output "postgres.*.private_ip" {
   value = "${join(",", aws_instance.postgres.*.private_ip)}"
 }
 
+output "elasticsearch.private_ip" {
+  value = "${aws_instance.elasticsearch.private_ip}"
+}
+
 output "router.*.ip" {
   value = "${join(",", aws_instance.router.*.private_ip)}"
 }

--- a/gce/dns-records.tf
+++ b/gce/dns-records.tf
@@ -53,6 +53,7 @@ resource "google_dns_record_set" "postgresapi" {
   ttl = "60"
   rrdatas = ["${google_compute_forwarding_rule.router_https.ip_address}"]
 }
+
 resource "google_dns_record_set" "grafana" {
   managed_zone = "${var.dns_zone_id}"
   name = "${var.env}-grafana.${var.dns_zone_name}"
@@ -61,3 +62,10 @@ resource "google_dns_record_set" "grafana" {
   rrdatas = ["${google_compute_instance.influx-grafana.network_interface.0.access_config.0.nat_ip}"]
 }
 
+resource "google_dns_record_set" "elasticsearchapi" {
+  managed_zone = "${var.dns_zone_id}"
+  name = "${var.env}-elasticsearchapi.${var.dns_zone_name}"
+  type = "A"
+  ttl = "60"
+  rrdatas = ["${google_compute_forwarding_rule.router_https.ip_address}"]
+}

--- a/gce/elasticsearch.tf
+++ b/gce/elasticsearch.tf
@@ -1,0 +1,18 @@
+resource "google_compute_instance" "elasticsearch" {
+  name = "${var.env}-tsuru-elasticsearch"
+  machine_type = "n1-standard-1"
+  zone = "${element(split(",", var.gce_zones), count.index)}"
+  disk {
+    image = "${var.os_image}"
+  }
+  network_interface {
+    network = "${google_compute_network.network1.name}"
+  }
+  metadata {
+    sshKeys = "${var.user}:${file(\"${var.ssh_key_path}")}"
+  }
+  service_account {
+    scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
+  }
+  tags = [ "private" ]
+}

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -38,6 +38,10 @@ output "postgres.*.private_ip" {
   value = "${join(",", google_compute_instance.postgres.*.network_interface.0.address)}"
 }
 
+output "elasticsearch.private_ip" {
+  value = "${google_compute_instance.elasticsearch.network_interface.0.address}"
+}
+
 output "router.*.private_ip" {
   value = "${join(",", google_compute_instance.router.*.network_interface.0.address)}"
 }


### PR DESCRIPTION
Add elasticsearch server and DNS record for the elasticsearch broker. Elasticsearch service is required for the [performance tests](https://www.pivotaltracker.com/n/projects/1275640/stories/99395802). Elasticsearch DNS record is required to match our certificate wildcard. This way tsuru API can talk to elasticsearch broker deployed to tsuru.
