### PR TITLE
[#99782882] Set the influxDB retention policy

### DIFF
--- a/aws/influx.tf
+++ b/aws/influx.tf
@@ -8,5 +8,9 @@ resource "aws_instance" "influx-grafana" {
   tags = {
     Name = "${var.env}-influx-grafana"
   }
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 100
+  }
 }
 


### PR DESCRIPTION
GCE influxdb instance has 100GB disk, but AWS intance just had default volume (with about 7GB free) and was constantly running out of space. Add disk to AWS influxdb as well.

Thanks to the early disk fills and jenkins logs, I empirically determined that we use about 2GB space per day. 100GB should be enough for a month. We currently aim for 2 week retention policy, but for some (performance) tests we would have considerably more hosts. 100GB should be sufficient also for this use case.

Note: terraform doesn't apply (or even see) this change to the instance. You need to taint and re-create it to apply.
