### PR TITLE
[#100824938] Firewall core components for Google Compute Engine

### DIFF
--- a/gce/api-servers.tf
+++ b/gce/api-servers.tf
@@ -15,7 +15,7 @@ resource "google_compute_instance" "api" {
   service_account {
     scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
   }
-  tags = [ "private", "web" ]
+  tags = [ "private", "web", "api" ]
 }
 
 resource "google_compute_target_pool" "api" {

--- a/gce/coreos-docker-servers.tf
+++ b/gce/coreos-docker-servers.tf
@@ -17,7 +17,7 @@ resource "google_compute_instance" "coreos-docker" {
   service_account {
     scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
   }
-  tags = [ "private" ]
+  tags = [ "private", "docker-node" ]
 }
 
 resource "template_file" "etcd_cloud_config" {

--- a/gce/docker-registry.tf
+++ b/gce/docker-registry.tf
@@ -15,7 +15,7 @@ resource "google_compute_instance" "docker-registry" {
   service_account {
     scopes = [ "compute-ro", "storage-rw", "userinfo-email" ]
   }
-  tags = [ "private" ]
+  tags = [ "private", "docker-registry" ]
 }
 
 resource "google_storage_bucket" "registry-gcs" {

--- a/gce/elasticsearch.tf
+++ b/gce/elasticsearch.tf
@@ -14,5 +14,5 @@ resource "google_compute_instance" "elasticsearch" {
   service_account {
     scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
   }
-  tags = [ "private" ]
+  tags = [ "private", "elasticsearch" ]
 }

--- a/gce/influx.tf
+++ b/gce/influx.tf
@@ -16,6 +16,5 @@ resource "google_compute_instance" "influx-grafana" {
   service_account {
     scopes = [ "compute-ro", "storage-rw", "userinfo-email" ]
   }
-  tags = [ "public", "grafana" ]
+  tags = [ "public", "grafana", "influxdb" ]
 }
-

--- a/gce/mongo-redis.tf
+++ b/gce/mongo-redis.tf
@@ -14,5 +14,5 @@ resource "google_compute_instance" "db" {
   service_account {
     scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
   }
-  tags = [ "private" ]
+  tags = [ "private" , "mongo", "redis"]
 }

--- a/gce/postgres-servers.tf
+++ b/gce/postgres-servers.tf
@@ -15,7 +15,7 @@ resource "google_compute_instance" "postgres" {
   service_account {
     scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
   }
-  tags = [ "private" ]
+  tags = [ "private", "postgres" ]
 }
 
 resource "google_storage_bucket" "postgres-gcs" {

--- a/gce/routers.tf
+++ b/gce/routers.tf
@@ -15,7 +15,7 @@ resource "google_compute_instance" "router" {
   service_account {
     scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
   }
-  tags = [ "private", "web" ]
+  tags = [ "private", "web", "router" ]
 }
 
 resource "google_compute_target_pool" "router" {

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -208,3 +208,19 @@ resource "google_compute_firewall" "docker-node" {
     }
 }
 
+resource "google_compute_firewall" "docker-node-healthcheck" {
+    name = "${var.env}-docker-node-healthcheck-tsuru"
+    description = "Firewall rules for internal access to the docker servers for healthcheck"
+    network = "${google_compute_network.network1.name}"
+    source_ranges = [
+      "${google_compute_instance.api.*.network_interface.0.address}"
+    ]
+    source_tags = ["api"]
+    target_tags = ["docker-node"]
+
+    allow {
+        protocol = "tcp"
+        ports = ["1024-65535"]
+    }
+}
+

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -110,3 +110,18 @@ resource "google_compute_firewall" "grafana" {
   }
 }
 
+resource "google_compute_firewall" "influxdb" {
+  name = "${var.env}-influxdb-tsuru"
+  description = "Security group for influxdb that allows inbound traffic from all private machines"
+  network = "${google_compute_network.network1.name}"
+
+
+  source_tags = [ "private" ]
+  target_tags = [ "influxdb" ]
+
+  allow {
+    protocol = "tcp"
+    ports = [ 8086 ]
+  }
+}
+

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -224,3 +224,20 @@ resource "google_compute_firewall" "docker-node-healthcheck" {
     }
 }
 
+resource "google_compute_firewall" "docker-registry" {
+    name = "${var.env}-docker-registry-tsuru"
+    description = "Firewall rules for internal access to the docker registry servers"
+    network = "${google_compute_network.network1.name}"
+    source_ranges = [
+      "${google_compute_instance.coreos-docker.*.network_interface.0.address}",
+      "${google_compute_instance.api.*.network_interface.0.address}"
+    ]
+    source_tags = ["docker-node"]
+    target_tags = ["docker-registry"]
+
+    allow {
+        protocol = "tcp"
+        ports = ["6000"]
+    }
+}
+

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -241,3 +241,18 @@ resource "google_compute_firewall" "docker-registry" {
     }
 }
 
+resource "google_compute_firewall" "elasticsearch-internal" {
+    name = "${var.env}-elasticsearch-internal-tsuru"
+    description = "Firewall rules for internal access to the elasticsearch servers"
+    network = "${google_compute_network.network1.name}"
+    source_ranges = [
+      "${google_compute_instance.coreos-docker.*.network_interface.0.address}"
+    ]
+    source_tags = ["docker-node"]
+    target_tags = ["elasticsearch"]
+
+    allow {
+        protocol = "tcp"
+        ports = ["9200"]
+    }
+}

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -174,3 +174,20 @@ resource "google_compute_firewall" "redis" {
     }
 }
 
+resource "google_compute_firewall" "postgres" {
+    name = "${var.env}-postgres-tsuru"
+    description = "Firewall rules for internal access to the postgreSQL servers"
+    network = "${google_compute_network.network1.name}"
+    source_ranges = [
+      "${google_compute_instance.api.*.network_interface.0.address}",
+      "${google_compute_instance.coreos-docker.*.network_interface.0.address}"
+    ]
+    source_tags = ["api", "docker-node", "postgres"]
+    target_tags = ["postgres"]
+
+    allow {
+        protocol = "tcp"
+        ports = ["5432"]
+    }
+}
+

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -157,3 +157,20 @@ resource "google_compute_firewall" "mongodb" {
     }
 }
 
+resource "google_compute_firewall" "redis" {
+    name = "${var.env}-redis-tsuru"
+    description = "Firewall rules for internal access to the redis servers"
+    network = "${google_compute_network.network1.name}"
+    source_ranges = [
+      "${google_compute_instance.api.*.network_interface.0.address}",
+      "${google_compute_instance.router.*.network_interface.0.address}"
+    ]
+    source_tags = ["api", "router"]
+    target_tags = ["redis"]
+
+    allow {
+        protocol = "tcp"
+        ports = ["6379"]
+    }
+}
+

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -6,6 +6,22 @@ resource "google_compute_firewall" "internal" {
   source_tags = [ "public", "private" ]
   target_tags = [ "public", "private" ]
 
+  allow {
+    protocol = "tcp"
+    ports = [22]
+  }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+}
+
+resource "google_compute_firewall" "internal-to-nat" {
+  name = "${var.env}-tsuru-internal-to-nat"
+  description = "Security group for internally routed traffic to nat"
+  network = "${google_compute_network.network1.name}"
+
+  source_tags = [ "public", "private" ]
+  target_tags = [ "public", "nat" ]
+
   allow { protocol = "tcp" }
   allow { protocol = "udp" }
   allow { protocol = "icmp" }

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -191,3 +191,20 @@ resource "google_compute_firewall" "postgres" {
     }
 }
 
+resource "google_compute_firewall" "docker-node" {
+    name = "${var.env}-docker-node-tsuru"
+    description = "Firewall rules for internal access to the docker servers"
+    network = "${google_compute_network.network1.name}"
+    source_ranges = [
+      "${google_compute_instance.api.*.network_interface.0.address}",
+      "${google_compute_instance.gandalf.network_interface.0.address}"
+    ]
+    source_tags = ["api", "gandalf"]
+    target_tags = ["docker-node"]
+
+    allow {
+        protocol = "tcp"
+        ports = ["4243"]
+    }
+}
+

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -27,6 +27,24 @@ resource "google_compute_firewall" "internal-to-nat" {
   allow { protocol = "icmp" }
 }
 
+resource "google_compute_firewall" "router" {
+  name = "${var.env}-router-tsuru"
+  description = "Security group for router traffic"
+  network = "${google_compute_network.network1.name}"
+
+  source_ranges = [
+    "${google_compute_instance.coreos-docker.*.network_interface.0.address}"
+  ]
+  source_tags = [ "router" ]
+  target_tags = [ "docker-node" ]
+
+  allow {
+    protocol = "tcp"
+    ports = ["1024-65535"]
+  }
+
+}
+
 resource "google_compute_firewall" "nat" {
   name = "${var.env}-nat-tsuru"
   description = "Security group for nat instances that allows SSH and VPN traffic from internet"

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -141,3 +141,19 @@ resource "google_compute_firewall" "api" {
     }
 }
 
+resource "google_compute_firewall" "mongodb" {
+    name = "${var.env}-mongodb-tsuru"
+    description = "Firewall rules for internal access to the mongodb servers"
+    network = "${google_compute_network.network1.name}"
+    source_ranges = [
+      "${google_compute_instance.api.*.network_interface.0.address}"
+    ]
+    source_tags = ["api", "gandalf"]
+    target_tags = ["mongo"]
+
+    allow {
+        protocol = "tcp"
+        ports = ["27017"]
+    }
+}
+

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -125,3 +125,19 @@ resource "google_compute_firewall" "influxdb" {
   }
 }
 
+resource "google_compute_firewall" "api" {
+    name = "${var.env}-api-tsuru"
+    description = "Firewall rules for internal access to the api servers"
+    network = "${google_compute_network.network1.name}"
+    source_ranges = [
+      "${google_compute_instance.gandalf.network_interface.0.address}"
+    ]
+    source_tags = ["gandalf"]
+    target_tags = ["api"]
+
+    allow {
+        protocol = "tcp"
+        ports = ["80"]
+    }
+}
+


### PR DESCRIPTION
[Firewall core components](https://www.pivotaltracker.com/story/show/100824938)

**What**

Prior to any security testing and now that we understand the architecture better, we should configure firewalls to ensure that only whitelisted components/machines can talk to each other. All routes should be blacklisted by default and only opened if required.

**How this PR should be reviewed**

This PR has been written to be reviewed in the following context:
- I want to give each host type a tag that I can use latter to assign those hosts to specific security groups
- I want to restrict access within the infrastructure and limit only ssh traffic by default
- I want to allow the machines with in the private network to go out and get their updates
- I want to allow the following access rules:
  - Routers -> Docker Nodes on non privileged ports
  - All internal machines to log their telegraf data to influxdb
  - Gandalf -> Tsuru API on port 80
  - Gandalf and Tsuru API -> Mongodb on port 27107
  - API and Routers -> Redis on port 6379
  - API, Docker nodes and Postgres -> Postgres on port 5432
  - API and Gandalf -> Docker node on port 4243
  - API -> Docker nodes to run healthchecks on non privileged ports
  - Docker nodes -> Docker Registry on port 6000
  - Docker nodes -> Elasticsearch on port 9200

**How to test this PR**

To test this PR you can do the following:
- Create a new environment using this branch
- Do an ansible run and the run a smoketest of the environment
- Check that dashboard app is running
- Deploy a new app using any of the example applications available e.g. [example-java-jetty](https://github.com/alphagov/example-java-jetty) and verify that it is running
- Use tsuru app-deploy to deploy an application
- Connect to the postgresql master and slave and verify that they are in sync with the same databases
- Connect to the grafana dashboard and verify that data is coming in
- The examples above are just a sample of things you could try, please feel free to try more tests e.g. internal connectivity using nc or nmap.

**Who should review this PR**
- A Cheerful Chimpmunk, if a suitably jolly striped rodent is not to hand then any member of the core team can weigh in.
- Anyone on the core team can merge this PR with the exception of @RichardKnop who I paired with
