### PR TITLE
[#100824938] Firewall core components for AWS

### DIFF
--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -18,8 +18,7 @@ resource "aws_elb" "api-ext" {
   name = "${var.env}-tsuru-api-elb-ext"
   subnets = ["${aws_subnet.public.*.id}"]
   security_groups = [
-    "${aws_security_group.web.id}",
-    "${aws_security_group.tsuru_api_external_loadbalancer.id}"
+    "${aws_security_group.web.id}"
   ]
   instances = ["${aws_instance.api.*.id}"]
 
@@ -43,8 +42,7 @@ resource "aws_elb" "api-int" {
   subnets = ["${aws_subnet.private.*.id}"]
   internal = true
   security_groups = [
-    "${aws_security_group.web.id}",
-    "${aws_security_group.tsuru_api_internal_loadbalancer.id}"
+    "${aws_security_group.web.id}"
   ]
   instances = ["${aws_instance.api.*.id}"]
 
@@ -63,47 +61,26 @@ resource "aws_elb" "api-int" {
   }
 }
 
-resource "aws_security_group" "tsuru_api_external_loadbalancer" {
-  name = "${var.env}-tsuru-api-external-loadbalancer"
-  description = "Tsuru API external load balancer security group"
-  vpc_id = "${aws_vpc.default.id}"
-
-  tags = {
-    Name = "${var.env}-tsuru-api-external-loadbalancer"
-  }
-}
-
-resource "aws_security_group" "tsuru_api_internal_loadbalancer" {
-  name = "${var.env}-tsuru-api-internal-loadbalancer"
-  description = "Tsuru API internal load balancer security group"
-  vpc_id = "${aws_vpc.default.id}"
-
-  ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-    security_groups = [
-      "${aws_security_group.gandalf.id}",
-    ]
-  }
-
-  tags = {
-    Name = "${var.env}-tsuru-api-internal-loadbalancer"
-  }
-}
-
 resource "aws_security_group" "tsuru_api" {
   name = "${var.env}-tsuru-api"
   description = "Tsuru API security group"
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
     security_groups = [
-      "${aws_security_group.tsuru_api_external_loadbalancer.id}",
-      "${aws_security_group.tsuru_api_internal_loadbalancer.id}"
+      "${aws_security_group.web.id}"
+    ]
+  }
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [
+      "${aws_security_group.web.id}"
     ]
   }
 

--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -4,7 +4,10 @@ resource "aws_instance" "api" {
   instance_type = "t2.medium"
   subnet_id = "${element(aws_subnet.private.*.id, count.index)}"
   availability_zone = "${element(aws_subnet.private.*.availability_zone, count.index)}"
-  security_groups = ["${aws_security_group.default.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.tsuru_api.id}"
+  ]
   key_name = "${var.key_pair_name}"
   tags = {
     Name = "${var.env}-tsuru-api-${count.index}"
@@ -52,4 +55,10 @@ resource "aws_elb" "api-int" {
     lb_port = 443
     lb_protocol = "tcp"
   }
+}
+
+resource "aws_security_group" "tsuru_api" {
+  name = "tsuru_api"
+  description = "Tsuru API security group"
+  vpc_id = "${aws_vpc.default.id}"
 }

--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -42,7 +42,8 @@ resource "aws_elb" "api-int" {
   subnets = ["${aws_subnet.private.*.id}"]
   internal = true
   security_groups = [
-    "${aws_security_group.web.id}"
+    "${aws_security_group.web.id}",
+    "${aws_security_group.tsuru_api_int_elb.id}"
   ]
   instances = ["${aws_instance.api.*.id}"]
 
@@ -58,6 +59,25 @@ resource "aws_elb" "api-int" {
     instance_protocol = "tcp"
     lb_port = 443
     lb_protocol = "tcp"
+  }
+}
+
+resource "aws_security_group" "tsuru_api_int_elb" {
+  name = "${var.env}-tsuru-api-int-elb"
+  description = "Tsuru API Internal ELB security group"
+  vpc_id = "${aws_vpc.default.id}"
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [
+      "${aws_security_group.gandalf.id}"
+    ]
+  }
+
+  tags = {
+    Name = "${var.env}-tsuru-api-int-elb"
   }
 }
 

--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -78,6 +78,15 @@ resource "aws_security_group" "tsuru_api_internal_loadbalancer" {
   description = "Tsuru API internal load balancer security group"
   vpc_id = "${aws_vpc.default.id}"
 
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    security_groups = [
+      "${aws_security_group.gandalf.id}",
+    ]
+  }
+
   tags = {
     Name = "${var.env}-tsuru-api-internal-loadbalancer"
   }

--- a/aws/api-servers.tf
+++ b/aws/api-servers.tf
@@ -67,15 +67,6 @@ resource "aws_security_group" "tsuru_api" {
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-    from_port       = 80
-    to_port         = 80
-    protocol        = "tcp"
-    security_groups = [
-      "${aws_security_group.web.id}"
-    ]
-  }
-
-  ingress {
     from_port       = 443
     to_port         = 443
     protocol        = "tcp"

--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -44,7 +44,6 @@ resource "aws_security_group" "docker_node" {
       to_port = 4243
       protocol = "tcp"
       security_groups = [
-        "${aws_security_group.tsuru_api.id}",
         "${aws_security_group.router.id}"
       ]
   }

--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -44,7 +44,24 @@ resource "aws_security_group" "docker_node" {
       to_port = 65535
       protocol = "tcp"
       security_groups = [
-        "${aws_security_group.tsuru_api.id}",
+        "${aws_security_group.tsuru_api.id}"
+      ]
+  }
+
+  ingress {
+      from_port = 1024
+      to_port = 4242
+      protocol = "tcp"
+      security_groups = [
+        "${aws_security_group.router.id}"
+      ]
+  }
+
+  ingress {
+      from_port = 4244
+      to_port = 65535
+      protocol = "tcp"
+      security_groups = [
         "${aws_security_group.router.id}"
       ]
   }

--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -49,6 +49,15 @@ resource "aws_security_group" "docker_node" {
       ]
   }
 
+  ingress {
+      from_port = 1024
+      to_port = 65535
+      protocol = "tcp"
+      security_groups = [
+        "${aws_security_group.tsuru_api.id}"
+      ]
+  }
+
   tags = {
     Name = "${var.env}-tsuru-coreos-docker"
   }

--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -5,7 +5,10 @@ resource "aws_instance" "coreos-docker" {
   instance_type = "t2.medium"
   subnet_id = "${element(aws_subnet.private.*.id, count.index)}"
   availability_zone = "${element(aws_subnet.private.*.availability_zone, count.index)}"
-  security_groups = ["${aws_security_group.default.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.docker_node.id}"
+  ]
   key_name = "${var.key_pair_name}"
   tags = {
     Name = "${var.env}-tsuru-coreos-docker-${count.index}"
@@ -28,5 +31,21 @@ resource "template_file" "etcd_discovery_url" {
     local-exec {
       command = "curl https://discovery.etcd.io/new?size=${var.docker_count} > ETCD_CLUSTER_ID"
     }
+  }
+}
+
+resource "aws_security_group" "docker_node" {
+  name = "docker_node"
+  description = "Docker Node security group"
+  vpc_id = "${aws_vpc.default.id}"
+
+  ingress {
+      from_port = 0
+      to_port = 4243
+      protocol = "tcp"
+      security_groups = [
+        "${aws_security_group.tsuru_api.id}",
+        "${aws_security_group.router.id}"
+      ]
   }
 }

--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -40,7 +40,7 @@ resource "aws_security_group" "docker_node" {
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-      from_port = 0
+      from_port = 4243
       to_port = 4243
       protocol = "tcp"
       security_groups = [

--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -35,7 +35,7 @@ resource "template_file" "etcd_discovery_url" {
 }
 
 resource "aws_security_group" "docker_node" {
-  name = "docker_node"
+  name = "${var.env}-docker-node"
   description = "Docker Node security group"
   vpc_id = "${aws_vpc.default.id}"
 
@@ -47,5 +47,9 @@ resource "aws_security_group" "docker_node" {
         "${aws_security_group.tsuru_api.id}",
         "${aws_security_group.router.id}"
       ]
+  }
+
+  tags = {
+    Name = "${var.env}-tsuru-coreos-docker"
   }
 }

--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -40,20 +40,12 @@ resource "aws_security_group" "docker_node" {
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-      from_port = 4243
-      to_port = 4243
-      protocol = "tcp"
-      security_groups = [
-        "${aws_security_group.router.id}"
-      ]
-  }
-
-  ingress {
       from_port = 1024
       to_port = 65535
       protocol = "tcp"
       security_groups = [
-        "${aws_security_group.tsuru_api.id}"
+        "${aws_security_group.tsuru_api.id}",
+        "${aws_security_group.router.id}"
       ]
   }
 

--- a/aws/docker-registry.tf
+++ b/aws/docker-registry.tf
@@ -50,7 +50,10 @@ resource "aws_instance" "docker-registry" {
   ami = "${lookup(var.ubuntu_amis, var.region)}"
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.private.0.id}"
-  security_groups = ["${aws_security_group.default.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.docker_registry.id}"
+  ]
   key_name = "${var.key_pair_name}"
   iam_instance_profile = "${var.registry_s3_rolename}"
   tags = {
@@ -68,3 +71,17 @@ resource "aws_s3_bucket" "registry-s3" {
     force_destroy = "${var.force_destroy}"
 }
 
+resource "aws_security_group" "docker_registry" {
+  name = "docker_registry"
+  description = "Docker Node security group"
+  vpc_id = "${aws_vpc.default.id}"
+
+  ingress {
+      from_port = 0
+      to_port = 6000
+      protocol = "tcp"
+      security_groups = [
+        "${aws_security_group.docker_node.id}"
+      ]
+  }
+}

--- a/aws/docker-registry.tf
+++ b/aws/docker-registry.tf
@@ -72,7 +72,7 @@ resource "aws_s3_bucket" "registry-s3" {
 }
 
 resource "aws_security_group" "docker_registry" {
-  name = "docker_registry"
+  name = "${var.env}-docker-registry"
   description = "Docker Node security group"
   vpc_id = "${aws_vpc.default.id}"
 
@@ -83,5 +83,9 @@ resource "aws_security_group" "docker_registry" {
       security_groups = [
         "${aws_security_group.docker_node.id}"
       ]
+  }
+
+  tags = {
+    Name = "${var.env}-tsuru-registry"
   }
 }

--- a/aws/docker-registry.tf
+++ b/aws/docker-registry.tf
@@ -77,10 +77,11 @@ resource "aws_security_group" "docker_registry" {
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-      from_port = 0
+      from_port = 6000
       to_port = 6000
       protocol = "tcp"
       security_groups = [
+      "${aws_security_group.tsuru_api.id}",
         "${aws_security_group.docker_node.id}"
       ]
   }

--- a/aws/elasticsearch.tf
+++ b/aws/elasticsearch.tf
@@ -2,8 +2,30 @@ resource "aws_instance" "elasticsearch" {
   ami = "${lookup(var.ubuntu_amis, var.region)}"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.private.0.id}"
-  security_groups = ["${aws_security_group.default.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.elasticsearch.id}"
+  ]
   key_name = "${var.key_pair_name}"
+  tags = {
+    Name = "${var.env}-tsuru-elasticsearch"
+  }
+}
+
+resource "aws_security_group" "elasticsearch" {
+  name = "${var.env}-elasticsearch"
+  description = "Elasticsearch security group"
+  vpc_id = "${aws_vpc.default.id}"
+
+  ingress {
+    from_port = 0
+    to_port   = 9200
+    protocol  = "tcp"
+    security_groups = [
+      "${aws_security_group.docker_node.id}"
+    ]
+  }
+
   tags = {
     Name = "${var.env}-tsuru-elasticsearch"
   }

--- a/aws/elasticsearch.tf
+++ b/aws/elasticsearch.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "elasticsearch" {
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-    from_port = 0
+    from_port = 9200
     to_port   = 9200
     protocol  = "tcp"
     security_groups = [

--- a/aws/gandalf.tf
+++ b/aws/gandalf.tf
@@ -41,6 +41,15 @@ resource "aws_security_group" "gandalf" {
       ]
   }
 
+  ingress {
+      from_port = 3232
+      to_port = 3232
+      protocol = "tcp"
+      security_groups = [
+        "${aws_security_group.tsuru_api.id}",
+      ]
+  }
+
   tags {
     Name = "${var.env}-tsuru-gandalf"
   }

--- a/aws/gandalf.tf
+++ b/aws/gandalf.tf
@@ -10,3 +10,26 @@ resource "aws_instance" "gandalf" {
   }
 }
 
+resource "aws_security_group" "gandalf" {
+  name = "${var.env}-tsuru-gandalf"
+  description = "Security group for Gandalf instance that allows SSH access from internet"
+  vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
+  }
+
+  tags {
+    Name = "${var.env}-tsuru-gandalf"
+  }
+}

--- a/aws/gandalf.tf
+++ b/aws/gandalf.tf
@@ -32,6 +32,15 @@ resource "aws_security_group" "gandalf" {
     cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
   }
 
+  ingress {
+      from_port = 8080
+      to_port = 8080
+      protocol = "tcp"
+      security_groups = [
+        "${aws_security_group.tsuru_api.id}",
+      ]
+  }
+
   tags {
     Name = "${var.env}-tsuru-gandalf"
   }

--- a/aws/gandalf.tf
+++ b/aws/gandalf.tf
@@ -3,7 +3,10 @@ resource "aws_instance" "gandalf" {
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.public.0.id}"
   associate_public_ip_address = true
-  security_groups = ["${aws_security_group.default.id}", "${aws_security_group.gandalf.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.gandalf.id}"
+  ]
   key_name = "${var.key_pair_name}"
   tags = {
     Name = "${var.env}-tsuru-gandalf"

--- a/aws/gandalf.tf
+++ b/aws/gandalf.tf
@@ -47,6 +47,7 @@ resource "aws_security_group" "gandalf" {
       protocol = "tcp"
       security_groups = [
         "${aws_security_group.tsuru_api.id}",
+        "${aws_security_group.docker_node.id}"
       ]
   }
 

--- a/aws/influx.tf
+++ b/aws/influx.tf
@@ -3,7 +3,10 @@ resource "aws_instance" "influx-grafana" {
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.public.0.id}"
   associate_public_ip_address = true
-  security_groups = ["${aws_security_group.default.id}", "${aws_security_group.grafana.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.grafana.id}"
+  ]
   key_name = "${var.key_pair_name}"
   tags = {
     Name = "${var.env}-influx-grafana"
@@ -14,3 +17,33 @@ resource "aws_instance" "influx-grafana" {
   }
 }
 
+resource "aws_security_group" "grafana" {
+  name = "${var.env}-grafana-tsuru"
+  description = "Security group for grafana that allows traffic from the office"
+  vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 3000
+    to_port   = 3000
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
+  }
+
+  ingress {
+    from_port = 8083
+    to_port   = 8083
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
+  }
+
+  tags {
+    Name = "${var.env}-influx-grafana"
+  }
+}

--- a/aws/influx.tf
+++ b/aws/influx.tf
@@ -43,6 +43,13 @@ resource "aws_security_group" "grafana" {
     cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
   }
 
+  ingress {
+    from_port = 8086
+    to_port   = 8086
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
+  }
+
   tags {
     Name = "${var.env}-influx-grafana"
   }

--- a/aws/influx.tf
+++ b/aws/influx.tf
@@ -47,7 +47,9 @@ resource "aws_security_group" "grafana" {
     from_port = 8086
     to_port   = 8086
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
+    security_groups = [
+      "${aws_security_group.default.id}"
+    ]
   }
 
   tags {

--- a/aws/mongo-redis.tf
+++ b/aws/mongo-redis.tf
@@ -3,6 +3,7 @@ resource "aws_instance" "tsuru-db" {
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.private.0.id}"
   security_groups = [
+    "${aws_security_group.default.id}",
     "${aws_security_group.mongodb.id}",
     "${aws_security_group.redis.id}"
   ]

--- a/aws/mongo-redis.tf
+++ b/aws/mongo-redis.tf
@@ -4,6 +4,7 @@ resource "aws_instance" "tsuru-db" {
   subnet_id = "${aws_subnet.private.0.id}"
   security_groups = [
     "${aws_security_group.default.id}",
+    "${aws_security_group.mongodb.id}",
     "${aws_security_group.redis.id}"
   ]
   key_name = "${var.key_pair_name}"
@@ -12,6 +13,21 @@ resource "aws_instance" "tsuru-db" {
   }
 }
 
+resource "aws_security_group" "mongodb" {
+  name = "mongodb"
+  description = "MongoDB security group"
+  vpc_id = "${aws_vpc.default.id}"
+
+  ingress {
+      from_port = 0
+      to_port = 27017
+      protocol = "tcp"
+      security_groups = [
+        "${aws_security_group.tsuru_api.id}",
+        "${aws_security_group.gandalf.id}"
+      ]
+  }
+}
 
 resource "aws_security_group" "redis" {
   name = "redis"

--- a/aws/mongo-redis.tf
+++ b/aws/mongo-redis.tf
@@ -19,7 +19,7 @@ resource "aws_security_group" "mongodb" {
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-      from_port = 0
+      from_port = 27017
       to_port = 27017
       protocol = "tcp"
       security_groups = [
@@ -39,7 +39,7 @@ resource "aws_security_group" "redis" {
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-      from_port = 0
+      from_port = 6379
       to_port = 6379
       protocol = "tcp"
       security_groups = [

--- a/aws/mongo-redis.tf
+++ b/aws/mongo-redis.tf
@@ -13,7 +13,7 @@ resource "aws_instance" "tsuru-db" {
 }
 
 resource "aws_security_group" "mongodb" {
-  name = "mongodb"
+  name = "${var.env}-mongodb"
   description = "MongoDB security group"
   vpc_id = "${aws_vpc.default.id}"
 
@@ -26,10 +26,14 @@ resource "aws_security_group" "mongodb" {
         "${aws_security_group.gandalf.id}"
       ]
   }
+
+  tags = {
+    Name = "${var.env}-tsuru-db"
+  }
 }
 
 resource "aws_security_group" "redis" {
-  name = "redis"
+  name = "${var.env}-redis"
   description = "Redis security group"
   vpc_id = "${aws_vpc.default.id}"
 
@@ -41,5 +45,9 @@ resource "aws_security_group" "redis" {
         "${aws_security_group.tsuru_api.id}",
         "${aws_security_group.router.id}"
       ]
+  }
+
+  tags = {
+    Name = "${var.env}-tsuru-db"
   }
 }

--- a/aws/mongo-redis.tf
+++ b/aws/mongo-redis.tf
@@ -3,7 +3,6 @@ resource "aws_instance" "tsuru-db" {
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.private.0.id}"
   security_groups = [
-    "${aws_security_group.default.id}",
     "${aws_security_group.mongodb.id}",
     "${aws_security_group.redis.id}"
   ]

--- a/aws/mongo-redis.tf
+++ b/aws/mongo-redis.tf
@@ -2,10 +2,29 @@ resource "aws_instance" "tsuru-db" {
   ami = "${lookup(var.ubuntu_amis, var.region)}"
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.private.0.id}"
-  security_groups = ["${aws_security_group.default.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.redis.id}"
+  ]
   key_name = "${var.key_pair_name}"
   tags = {
     Name = "${var.env}-tsuru-db"
   }
 }
 
+
+resource "aws_security_group" "redis" {
+  name = "redis"
+  description = "Redis security group"
+  vpc_id = "${aws_vpc.default.id}"
+
+  ingress {
+      from_port = 0
+      to_port = 6379
+      protocol = "tcp"
+      security_groups = [
+        "${aws_security_group.tsuru_api.id}",
+        "${aws_security_group.router.id}"
+      ]
+  }
+}

--- a/aws/nat-server.tf
+++ b/aws/nat-server.tf
@@ -2,7 +2,10 @@ resource "aws_instance" "nat" {
   ami = "${lookup(var.ubuntu_amis, var.region)}"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public.0.id}"
-  security_groups = ["${aws_security_group.default.id}", "${aws_security_group.nat.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.nat.id}"
+  ]
   key_name = "${var.key_pair_name}"
   source_dest_check = false
   tags = {
@@ -16,3 +19,28 @@ resource "aws_instance" "nat" {
     script = "../setup-nat-routing.sh"
   }
 }
+
+resource "aws_security_group" "nat" {
+  name = "${var.env}-nat-tsuru"
+  description = "Security group for nat instances that allows SSH and VPN traffic from internet"
+  vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
+  }
+
+  tags {
+    Name = "${var.env}-tsuru-nat"
+  }
+}
+

--- a/aws/nat-server.tf
+++ b/aws/nat-server.tf
@@ -33,9 +33,18 @@ resource "aws_security_group" "nat" {
   }
 
   ingress {
-    from_port = 22
-    to_port   = 22
-    protocol  = "tcp"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    security_groups = [
+      "${aws_security_group.default.id}"
+    ]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
     cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
   }
 
@@ -43,4 +52,3 @@ resource "aws_security_group" "nat" {
     Name = "${var.env}-tsuru-nat"
   }
 }
-

--- a/aws/postgres-servers.tf
+++ b/aws/postgres-servers.tf
@@ -74,7 +74,7 @@ resource "aws_security_group" "postgres" {
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-    from_port = 0
+    from_port = 5432
     to_port   = 5432
     protocol  = "tcp"
     security_groups = [

--- a/aws/postgres-servers.tf
+++ b/aws/postgres-servers.tf
@@ -51,7 +51,10 @@ resource "aws_instance" "postgres" {
   instance_type = "t2.micro"
   subnet_id = "${element(aws_subnet.private.*.id, count.index)}"
   availability_zone = "${element(aws_subnet.private.*.availability_zone, count.index)}"
-  security_groups = ["${aws_security_group.default.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.postgres.id}"
+  ]
   iam_instance_profile = "${var.postgres_s3_rolename}"
   key_name = "${var.key_pair_name}"
   tags = {
@@ -65,3 +68,21 @@ resource "aws_s3_bucket" "postgres-s3" {
     force_destroy = "${var.force_destroy}"
 }
 
+resource "aws_security_group" "postgres" {
+  name = "${var.env}-postgres"
+  description = "Postgres security group"
+  vpc_id = "${aws_vpc.default.id}"
+
+  ingress {
+    from_port = 0
+    to_port   = 5432
+    protocol  = "tcp"
+    security_groups = [
+      "${aws_security_group.docker_node.id}"
+    ]
+  }
+
+  tags = {
+    Name = "${var.env}-tsuru-postgres-${count.index}"
+  }
+}

--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -4,7 +4,10 @@ resource "aws_instance" "router" {
   instance_type = "t2.medium"
   subnet_id = "${element(aws_subnet.private.*.id, count.index)}"
   availability_zone = "${element(aws_subnet.private.*.availability_zone, count.index)}"
-  security_groups = ["${aws_security_group.default.id}"]
+  security_groups = [
+    "${aws_security_group.default.id}",
+    "${aws_security_group.router.id}"
+  ]
   key_name = "${var.key_pair_name}"
   tags = {
     Name = "${var.env}-tsuru-router-${count.index}"
@@ -36,4 +39,10 @@ resource "aws_elb" "router" {
     lb_port = 443
     lb_protocol = "tcp"
   }
+}
+
+resource "aws_security_group" "router" {
+  name = "router"
+  description = "Router security group"
+  vpc_id = "${aws_vpc.default.id}"
 }

--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -19,7 +19,6 @@ resource "aws_elb" "router" {
   subnets = ["${aws_subnet.public.*.id}"]
   security_groups = [
     "${aws_security_group.web.id}",
-    "${aws_security_group.router_loadbalancer.id}",
   ]
   instances = ["${aws_instance.router.*.id}"]
 
@@ -44,16 +43,6 @@ resource "aws_elb" "router" {
   }
 }
 
-resource "aws_security_group" "router_loadbalancer" {
-  name = "${var.env}-router_loadbalancer"
-  description = "Router load balancer security group"
-  vpc_id = "${aws_vpc.default.id}"
-
-  tags = {
-    Name = "${var.env}-tsuru-router-loadbalancer"
-  }
-}
-
 resource "aws_security_group" "router" {
   name = "${var.env}-router"
   description = "Router security group"
@@ -64,7 +53,7 @@ resource "aws_security_group" "router" {
     to_port   = 80
     protocol  = "tcp"
     security_groups = [
-      "${aws_security_group.router_loadbalancer.id}",
+      "${aws_security_group.web.id}"
     ]
   }
 
@@ -73,7 +62,7 @@ resource "aws_security_group" "router" {
     to_port   = 443
     protocol  = "tcp"
     security_groups = [
-      "${aws_security_group.router_loadbalancer.id}",
+      "${aws_security_group.web.id}"
     ]
   }
 

--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -42,7 +42,11 @@ resource "aws_elb" "router" {
 }
 
 resource "aws_security_group" "router" {
-  name = "router"
+  name = "${var.env}-router"
   description = "Router security group"
   vpc_id = "${aws_vpc.default.id}"
+
+  tags = {
+    Name = "${var.env}-tsuru-router"
+  }
 }

--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -49,18 +49,18 @@ resource "aws_security_group" "router" {
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
-    from_port = 80
-    to_port   = 80
-    protocol  = "tcp"
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
     security_groups = [
       "${aws_security_group.web.id}"
     ]
   }
 
   ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
     security_groups = [
       "${aws_security_group.web.id}"
     ]

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -84,37 +84,6 @@ resource "aws_security_group" "web" {
   }
 }
 
-resource "aws_security_group" "grafana" {
-  name = "${var.env}-grafana-tsuru"
-  description = "Security group for grafana that allows traffic from the office"
-  vpc_id = "${aws_vpc.default.id}"
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = 3000
-    to_port   = 3000
-    protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
-  }
-
-  ingress {
-    from_port = 8083
-    to_port   = 8083
-    protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
-  }
-
-  tags {
-    Name = "${var.env}-influx-grafana"
-  }
-}
-
 /* FIXME: Unused, remove when deployed to CI */
 resource "aws_security_group" "web-int" {
   name = "${var.env}-web-int-tsuru"

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -22,30 +22,6 @@ resource "aws_security_group" "default" {
   }
 }
 
-resource "aws_security_group" "nat" {
-  name = "${var.env}-nat-tsuru"
-  description = "Security group for nat instances that allows SSH and VPN traffic from internet"
-  vpc_id = "${aws_vpc.default.id}"
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = 22
-    to_port   = 22
-    protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}"]
-  }
-
-  tags {
-    Name = "${var.env}-tsuru-nat"
-  }
-}
-
 resource "aws_security_group" "web" {
   name = "${var.env}-web-tsuru"
   description = "Security group for web that allows web traffic from internet"

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -46,30 +46,6 @@ resource "aws_security_group" "nat" {
   }
 }
 
-resource "aws_security_group" "gandalf" {
-  name = "${var.env}-tsuru-gandalf"
-  description = "Security group for Gandalf instance that allows SSH access from internet"
-  vpc_id = "${aws_vpc.default.id}"
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = 22
-    to_port   = 22
-    protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}","${var.jenkins_elastic}","${aws_instance.nat.public_ip}/32"]
-  }
-
-  tags {
-    Name = "${var.env}-tsuru-gandalf"
-  }
-}
-
 resource "aws_security_group" "web" {
   name = "${var.env}-web-tsuru"
   description = "Security group for web that allows web traffic from internet"

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -1,20 +1,22 @@
 resource "aws_security_group" "default" {
   name = "${var.env}-default-tsuru"
-  description = "Default security group that allows inbound and outbound traffic from all instances in the VPC"
+  description = "Default security group which allows SSH access and outbound traffic"
   vpc_id = "${aws_vpc.default.id}"
 
+  # Allow inbound SSH access
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    self            = true
+  }
+
+  # Allow outbound traffic via NAT box
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port   = "0"
-    to_port     = "0"
-    protocol    = "-1"
-    self        = true
   }
 
   tags {


### PR DESCRIPTION
# What

Prior to any security testing and now that we understand the architecture better, we should configure firewalls to ensure that only whitelisted components/machines can talk to each other. All routes should be blacklisted by default and only opened if required.
# How this PR should be reviewed

This PR has been written to be reviewed in the following context:

I want to restrict access within the infrastructure and limit only ssh traffic by default

I want to allow the machines with in the private network to go out and get their updates

I want to allow the following access rules:
- Routers -> Docker Nodes on non privileged ports
- All internal machines to log their telegraf data to influxdb
- Gandalf -> Tsuru API on port 80
- Gandalf and Tsuru API -> Mongodb on port 27107
- API and Routers -> Redis on port 6379
- API, Docker nodes and Postgres -> Postgres on port 5432
- API and Gandalf -> Docker node on port 4243
- API -> Docker nodes to run healthchecks on non privileged ports
- Docker nodes -> Docker Registry on port 6000
- Docker nodes -> Elasticsearch on port 9200
# How to test this PR

To test this PR you can do the following:
- Create a new environment using this branch
- Do an ansible run and the run a smoketest of the environment
- Check that dashboard app is running
- Deploy a new app using any of the example applications available e.g. example-java-jetty and verify that it is running
- Use tsuru app-deploy to deploy an application
- Connect to the postgresql master and slave and verify that they are in sync with the same databases
- Connect to the grafana dashboard and verify that data is coming in

The examples above are just a sample of things you could try, please feel free to try more tests e.g. internal connectivity using nc or nmap.
# Who should review this PR

Anybody except Martin.
