### PR TITLE
[#101592538] coreos: only allow eth0 connections to docker

### DIFF
--- a/coreos-config.yaml.tpl
+++ b/coreos-config.yaml.tpl
@@ -22,6 +22,7 @@ coreos:
         ListenStream=4243
         Service=docker.service
         BindIPv6Only=both
+        BindToDevice=ens4v1
 
         [Install]
         WantedBy=sockets.target


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/101592538

Restrict docker daemon socket to accept connections only from eth0 (or ens4v1 as it is called in coreOS). This way locally running docker containers can't connect to docker daemon of their own host. To do that, they would first need to have guessed the host eth0 IP. They will however still get connection refused, exposing that a host with the attempted IP exists. Neverheless, given that connections to the docker daemon are only possible on eth0, we can restrict these fully with security group rules.

**To test**
0. Do points 2-4 to confirm the vulnerability. You should be able to connect and get docket version.
1. Apply. If applying against existing instances on GCE you will have to restart them for cloud-init to re-render the socket config and apply the changes.
2. ssh to coreOS node, find out locally running containers
3. do `docker exec -ti <containerID> bash` on coreOS node or `tsuru app-run -a <app_present_on_the_coreos_node> "<command from point 4>"`
4. run command accessing coreOS docker daemon socket, e.g. `curl <eth0_IP_of_coreOS_host>:4243/version` . Or you can try `telnet <coreOS eth0 ip> 4243...`
5. You should get connection refused.

@mtekel has implemented this, so he can't review...
