### PR TITLE
[#100824938] Allow only SSH to any host from NAT server

### DIFF
--- a/aws/nat-server.tf
+++ b/aws/nat-server.tf
@@ -22,7 +22,7 @@ resource "aws_instance" "nat" {
 
 resource "aws_security_group" "nat" {
   name = "${var.env}-nat-tsuru"
-  description = "Security group for nat instances that allows SSH from internet"
+  description = "Security group for nat instances that allows SSH from whitelisted IPs from internet"
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -8,7 +8,9 @@ resource "aws_security_group" "default" {
     from_port       = 22
     to_port         = 22
     protocol        = "tcp"
-    self            = true
+    security_groups = [
+      "${aws_security_group.nat.id}"
+    ]
   }
 
   # Allow outbound traffic via NAT box


### PR DESCRIPTION
[#100824938 Allow only SSH to any host from NAT server](https://www.pivotaltracker.com/story/show/100824938)
# What

Prior to any security testing and now that we understand the architecture better, we should configure firewalls to ensure that only whitelisted components/machines can talk to each other. 

In this PR we ensure that we can only can SSH the hosts via NAT servers.
# How this PR should be reviewed

This PR has been written to be reviewed in the following context:

I want to restrict access within the infrastructure and limit only ssh traffic by default via the NAT servers. The users will ssh to NAT and from there can SSH to any other host, but no other host can SSH to other hosts.
# How to test this PR

To test this PR you can do the following:
- Create a new environment using this branch
- Do an ansible run and the run a smoketest of the environment
- Check that dashboard app is running
- Confirm that you can SSH to any server using the NAT server (`ssh -F ssh.config <ip>`)
- Confirm that you cannot SSH to any other server from a non NAT server.

The examples above are just a sample of things you could try, please feel free to try more tests e.g. internal connectivity using nc or nmap.
# Who should review this PR

Anybody except @keymon or @RichardKnop .
