### PR TITLE
[100824938] Feature/gce firewall improvement: Allow only SSH from NAT

### DIFF
--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -73,6 +73,20 @@ resource "google_compute_firewall" "gandalf" {
   }
 }
 
+resource "google_compute_firewall" "docker-node-to-archive" {
+  name = "${var.env}-tsuru-docker-node-to-archive"
+  description = "Security group for Docker node to be able to pull files from the archive"
+  network = "${google_compute_network.network1.name}"
+
+  source_tags = [ "docker-node" ]
+  target_tags = [ "gandalf" ]
+
+  allow {
+    protocol = "tcp"
+    ports = [ 3232 ]
+  }
+}
+
 resource "google_compute_firewall" "web" {
   name = "${var.env}-web-tsuru"
   description = "Security group for web that allows web traffic from internet"

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -139,20 +139,18 @@ resource "google_compute_firewall" "influxdb" {
   }
 }
 
-resource "google_compute_firewall" "api" {
-    name = "${var.env}-api-tsuru"
-    description = "Firewall rules for internal access to the api servers"
-    network = "${google_compute_network.network1.name}"
-    source_ranges = [
-      "${google_compute_instance.gandalf.network_interface.0.address}"
-    ]
-    source_tags = ["gandalf"]
-    target_tags = ["api"]
+resource "google_compute_firewall" "api-to-gandalf" {
+  name = "${var.env}-tsuru-api-to-gandalf"
+  description = "Security group to allow 8080 and 3232 (archive) from API to Gandalf"
+  network = "${google_compute_network.network1.name}"
 
-    allow {
-        protocol = "tcp"
-        ports = ["80"]
-    }
+  source_tags = [ "api" ]
+  target_tags = [ "gandalf" ]
+
+  allow {
+    protocol = "tcp"
+    ports = [ 8080, 3232 ]
+  }
 }
 
 resource "google_compute_firewall" "mongodb" {

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -19,8 +19,8 @@ resource "google_compute_firewall" "internal-to-nat" {
   description = "Security group for internally routed traffic to nat"
   network = "${google_compute_network.network1.name}"
 
-  source_tags = [ "public", "private" ]
-  target_tags = [ "public", "nat" ]
+  source_tags = [ "private" ]
+  target_tags = [ "nat" ]
 
   allow { protocol = "tcp" }
   allow { protocol = "udp" }

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -182,7 +182,7 @@ resource "google_compute_firewall" "postgres" {
       "${google_compute_instance.api.*.network_interface.0.address}",
       "${google_compute_instance.coreos-docker.*.network_interface.0.address}"
     ]
-    source_tags = ["api", "docker-node", "postgres"]
+    source_tags = ["docker-node", "postgres"]
     target_tags = ["postgres"]
 
     allow {

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -4,7 +4,7 @@ resource "google_compute_firewall" "nat-to-internal" {
   network = "${google_compute_network.network1.name}"
 
   source_tags = [ "nat" ]
-  target_tags = [ "private" ]
+  target_tags = [ "private", "gandalf", "grafana" ]
 
   allow {
     protocol = "tcp"

--- a/gce/security-groups.tf
+++ b/gce/security-groups.tf
@@ -1,10 +1,10 @@
-resource "google_compute_firewall" "internal" {
-  name = "${var.env}-tsuru-internal"
+resource "google_compute_firewall" "nat-to-internal" {
+  name = "${var.env}-tsuru-nat-to-internal"
   description = "Security group for internally routed traffic"
   network = "${google_compute_network.network1.name}"
 
-  source_tags = [ "public", "private" ]
-  target_tags = [ "public", "private" ]
+  source_tags = [ "nat" ]
+  target_tags = [ "private" ]
 
   allow {
     protocol = "tcp"


### PR DESCRIPTION
[#100824938 Firewall core components](https://www.pivotaltracker.com/story/show/100824938)
# What

This PR improves the firewall rules for GCE.

SSH traffic has been limited so you cannot SSH from one instance to another inside the VPC. You have to go through NAT. 

While setting this rule we found some other misconfigured rules which we needed to update:
- Allow Docker node to connect to archive-server (3232 in gandalf node)
- Allow API to connect to Gandalf services
- Remove some unnecessary rules, like API to postgres
# How to Test

Create a new GCE environment from this branch. After provisioning, SSH to one of the instances and try:

`nc -v -w 1 <other_instance_IP> 22`

It should not work and time out.

Also run smoke tests and try deploying a sample app such as Flask test app.
# Who To Review

Not Richard or Hector.
