### PR TITLE
[#100824938] allow postgres to postgres communication on AWS

### DIFF
--- a/aws/postgres-servers.tf
+++ b/aws/postgres-servers.tf
@@ -77,6 +77,7 @@ resource "aws_security_group" "postgres" {
     from_port = 5432
     to_port   = 5432
     protocol  = "tcp"
+    self      = true
     security_groups = [
       "${aws_security_group.docker_node.id}"
     ]


### PR DESCRIPTION
From [#100824938 Firewall core components](https://www.pivotaltracker.com/story/show/100824938)
# What

Addition to previous PR #99 (check it out for further details), we missed check that postgres replication was working properly, which was not.

In this PR we allow postgres nodes to connect to other postgres nodes.

In the future, if we create multiple postgres clusters, we might restrict this per cluster, but that is out of scope.
# How this PR should be reviewed

This PR has been written to be reviewed in the following context:

With previous merged security groups which restrict access between components, I want to allow communication between postgres nodes.
# How to test this PR

To test it you can:
1. Provision a new environment with terraform.
2. Run ansible, you only need the postgres nodes, so you can limit it with `make aws DEPLOY_ENV=... ARGS='-l *-postgres*'`
3. Connect to the second postgres via SSH, and check that there are no errors in `/var/log/postgresql/postgresql-9.3-main.log` and you can connect to the first node using `psql` or `nc <ip> 5432`
# Who should review this PR

Anybody except @keymon or @RichardKnop .
