### PR TITLE
[#103903920] New terraform syntax for GCE account file

### DIFF
--- a/gce/provider.tf
+++ b/gce/provider.tf
@@ -1,5 +1,5 @@
 provider "google" {
-  account_file = "${var.gce_account_file}"
+  account_file = "${file("account.json")}"
   project = "${var.gce_project}"
   region = "${var.gce_region}"
 }

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -1,8 +1,3 @@
-variable "gce_account_file" {
-  description = "JSON Account Credentials file for GCE"
-  default = "account.json"
-}
-
 variable "gce_project" {
   description = "GCE Project Name to create machines inside of"
   default = "root-unison-859"


### PR DESCRIPTION
# What

The old syntax was deprecated in Terraform 0.6.2. The terraform upgrade was required because cloud foundry already uses the new version, where the new syntax is necessary.
# How to review
- Run `terraform plan` with master show the deprecation warning
- Run `terraform plan` with master will not show the deprecation warning
# Who can review

Anyone but @Jonty or @saliceti
