### PR TITLE
[#106189532] CoreOS image upgrade

### DIFF
--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -46,8 +46,8 @@ variable "ubuntu_amis" {
 variable "coreos_amis" {
   description = "AMIs to launch coreOS instances"
   default = {
-    eu-west-1 = "ami-0e104179"
-    eu-central-1 = "ami-b8cecaa5"
+    eu-west-1 = "ami-eb97bc9c"
+    eu-central-1 = "ami-840a0899"
   }
 }
 

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -35,7 +35,7 @@ variable "os_image" {
 
 variable "coreos_image" {
   description = "coreOS image to deploy our coreOS instances"
-  default = "coreos-stable-723-3-0-v20150804"
+  default = "coreos-stable-766-4-0-v20150929"
 }
 
 variable "network1_cidr" {


### PR DESCRIPTION
# What
- We need to bump the CoreOS version to avoid Tsuru logging problems with big sibling.
- New bs requires docker v 1.7.X
- This is necessary for PR https://github.com/alphagov/tsuru-ansible/pull/171
# How to review
- Provision new Tsuru environment 
- Run smoke test
# Who can review

Anyone apart @saliceti or @combor
