### PR TITLE
[#106191568] Add telegraf on coreos

### DIFF
--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -22,6 +22,7 @@ resource "template_file" "etcd_cloud_config" {
   vars {
     etcd_discovery_url = "${file("ETCD_CLUSTER_ID")}"
     docker_registry_host = "${replace(aws_route53_record.docker-registry.name, "/\.$/", ":${var.registry_port}")}"
+    influx_db_host = "${aws_instance.influx-grafana.private_ip}"
   }
 }
 

--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -11,7 +11,7 @@ resource "aws_instance" "coreos-docker" {
   ]
   key_name = "${var.key_pair_name}"
   tags = {
-    Name = "${element(template_file.etcd_cloud_config.*.vars.grafana_tag_job, count.index)}"
+    Name = "${element(template_file.etcd_cloud_config.*.vars.telegraf_tag_instance_name, count.index)}"
   }
   user_data = "${element(template_file.etcd_cloud_config.*.rendered, count.index)}"
 }
@@ -24,8 +24,8 @@ resource "template_file" "etcd_cloud_config" {
     etcd_discovery_url = "${file("ETCD_CLUSTER_ID")}"
     docker_registry_host = "${replace(aws_route53_record.docker-registry.name, "/\.$/", ":${var.registry_port}")}"
     influx_db_host = "${aws_instance.influx-grafana.private_ip}"
-    grafana_tag_job = "${var.env}-tsuru-coreos-docker-${count.index}"
-    grafana_tag_type = "coreos-docker"
+    telegraf_tag_instance_name = "${var.env}-tsuru-coreos-docker-${count.index}"
+    telegraf_tag_type = "coreos-docker"
   }
 }
 

--- a/aws/coreos-docker-servers.tf
+++ b/aws/coreos-docker-servers.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "coreos-docker" {
-  depends_on = [ "template_file.etcd_cloud_config" ]
+  depends_on = ["template_file.etcd_cloud_config"] 
   count = "${var.docker_count}"
   ami = "${lookup(var.coreos_amis, var.region)}"
   instance_type = "t2.medium"
@@ -11,7 +11,7 @@ resource "aws_instance" "coreos-docker" {
   ]
   key_name = "${var.key_pair_name}"
   tags = {
-    Name = "${element(template_file.etcd_cloud_config.*.vars.telegraf_tag_instance_name, count.index)}"
+    Name = "${var.env}-tsuru-coreos-docker-${count.index}"
   }
   user_data = "${element(template_file.etcd_cloud_config.*.rendered, count.index)}"
 }

--- a/aws/influx.tf
+++ b/aws/influx.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "influx-grafana" {
   ]
   key_name = "${var.key_pair_name}"
   tags = {
-    Name = "${var.env}-influx-grafana"
+    Name = "${var.env}-tsuru-influx-grafana"
   }
   root_block_device {
     volume_type = "gp2"

--- a/coreos-config.yaml.tpl
+++ b/coreos-config.yaml.tpl
@@ -52,7 +52,7 @@ coreos:
           -e TELEGRAF_INFLUX_DB_NAME=influxdb \
           -e TELEGRAF_INFLUX_DB_USER_NAME=influxdb \
           -e TELEGRAF_INFLUX_DB_PASSWORD=influxdb \
-          -e TELEGRAF_INFLUX_TAGS=job=\"${grafana_tag_job}\":type=\"${grafana_tag_type}\":host_ip=\"$private_ipv4\" \
+          -e TELEGRAF_INFLUX_TAGS=instance_name=\"${telegraf_tag_instance_name}\":type=\"${telegraf_tag_type}\":host_ip=\"$private_ipv4\" \
           saliceti/docker-telegraf
         ExecStop=/usr/bin/docker stop -t 2 telegraf
 

--- a/coreos-config.yaml.tpl
+++ b/coreos-config.yaml.tpl
@@ -53,7 +53,7 @@ coreos:
           -e TELEGRAF_INFLUX_DB_USER_NAME=influxdb \
           -e TELEGRAF_INFLUX_DB_PASSWORD=influxdb \
           -e TELEGRAF_INFLUX_TAGS=instance_name=\"${telegraf_tag_instance_name}\":type=\"${telegraf_tag_type}\":host_ip=\"$private_ipv4\" \
-          saliceti/docker-telegraf
+          governmentpaas/docker-telegraf
         ExecStop=/usr/bin/docker stop -t 2 telegraf
 
         [Install]

--- a/coreos-config.yaml.tpl
+++ b/coreos-config.yaml.tpl
@@ -53,6 +53,7 @@ coreos:
               -e TELEGRAF_INFLUX_DB_NAME=influxdb \
               -e TELEGRAF_INFLUX_DB_USER_NAME=influxdb \
               -e TELEGRAF_INFLUX_DB_PASSWORD=influxdb \
+              -e TELEGRAF_INFLUX_TAGS=job=\"runner\":host_ip=\"$private_ipv4\" \
               saliceti/docker-telegraf
             ExecStop=/usr/bin/docker stop -t 2 telegraf
 

--- a/coreos-config.yaml.tpl
+++ b/coreos-config.yaml.tpl
@@ -32,3 +32,29 @@ coreos:
           content: |
             [Service]
             Environment=DOCKER_OPTS='--insecure-registry="${docker_registry_host}"'
+    - name: telegraf.service
+      command: start
+      drop-ins:
+        - name: 50-docker-telegraf
+          content: |
+            [Unit]
+            Description=Telegraf container
+            Requires=docker.service
+            After=docker.service
+
+            [Service]
+            Restart=always
+            ExecStart=/usr/bin/docker run \
+              --name telegraf \
+              -v /proc:/host/proc \
+              -v /sys:/host/sys \
+              -v /dev:/host/dev \
+              -e TELEGRAF_INFLUX_DB_URL=http://${influx_db_host}:8086 \
+              -e TELEGRAF_INFLUX_DB_NAME=influxdb \
+              -e TELEGRAF_INFLUX_DB_USER_NAME=influxdb \
+              -e TELEGRAF_INFLUX_DB_PASSWORD=influxdb \
+              telegraf
+            ExecStop=/usr/bin/docker stop -t 2 telegraf
+
+            [Install]
+            WantedBy=local.target

--- a/coreos-config.yaml.tpl
+++ b/coreos-config.yaml.tpl
@@ -34,28 +34,27 @@ coreos:
             Environment=DOCKER_OPTS='--insecure-registry="${docker_registry_host}"'
     - name: telegraf.service
       command: start
-      drop-ins:
-        - name: 50-docker-telegraf
-          content: |
-            [Unit]
-            Description=Telegraf container
-            Requires=docker.service
-            After=docker.service
+      enable: true
+      content: |
+        [Unit]
+        Description=Telegraf container
+        Requires=docker.service
+        After=docker.service
 
-            [Service]
-            Restart=always
-            ExecStart=/usr/bin/docker run \
-              --name telegraf \
-              -v /proc:/host/proc \
-              -v /sys:/host/sys \
-              -v /dev:/host/dev \
-              -e TELEGRAF_INFLUX_DB_URL=http://${influx_db_host}:8086 \
-              -e TELEGRAF_INFLUX_DB_NAME=influxdb \
-              -e TELEGRAF_INFLUX_DB_USER_NAME=influxdb \
-              -e TELEGRAF_INFLUX_DB_PASSWORD=influxdb \
-              -e TELEGRAF_INFLUX_TAGS=job=\"runner\":host_ip=\"$private_ipv4\" \
-              saliceti/docker-telegraf
-            ExecStop=/usr/bin/docker stop -t 2 telegraf
+        [Service]
+        Restart=always
+        ExecStart=/usr/bin/docker run \
+          --name telegraf \
+          -v /proc:/host/proc \
+          -v /sys:/host/sys \
+          -v /dev:/host/dev \
+          -e TELEGRAF_INFLUX_DB_URL=http://${influx_db_host}:8086 \
+          -e TELEGRAF_INFLUX_DB_NAME=influxdb \
+          -e TELEGRAF_INFLUX_DB_USER_NAME=influxdb \
+          -e TELEGRAF_INFLUX_DB_PASSWORD=influxdb \
+          -e TELEGRAF_INFLUX_TAGS=job=\"runner\":host_ip=\"$private_ipv4\" \
+          saliceti/docker-telegraf
+        ExecStop=/usr/bin/docker stop -t 2 telegraf
 
-            [Install]
-            WantedBy=local.target
+        [Install]
+        WantedBy=local.target

--- a/coreos-config.yaml.tpl
+++ b/coreos-config.yaml.tpl
@@ -52,7 +52,7 @@ coreos:
           -e TELEGRAF_INFLUX_DB_NAME=influxdb \
           -e TELEGRAF_INFLUX_DB_USER_NAME=influxdb \
           -e TELEGRAF_INFLUX_DB_PASSWORD=influxdb \
-          -e TELEGRAF_INFLUX_TAGS=job=\"runner\":host_ip=\"$private_ipv4\" \
+          -e TELEGRAF_INFLUX_TAGS=job=\"${grafana_tag_job}\":type=\"${grafana_tag_type}\":host_ip=\"$private_ipv4\" \
           saliceti/docker-telegraf
         ExecStop=/usr/bin/docker stop -t 2 telegraf
 

--- a/coreos-config.yaml.tpl
+++ b/coreos-config.yaml.tpl
@@ -53,7 +53,7 @@ coreos:
               -e TELEGRAF_INFLUX_DB_NAME=influxdb \
               -e TELEGRAF_INFLUX_DB_USER_NAME=influxdb \
               -e TELEGRAF_INFLUX_DB_PASSWORD=influxdb \
-              telegraf
+              saliceti/docker-telegraf
             ExecStop=/usr/bin/docker stop -t 2 telegraf
 
             [Install]

--- a/gce/coreos-docker-servers.tf
+++ b/gce/coreos-docker-servers.tf
@@ -1,7 +1,7 @@
 resource "google_compute_instance" "coreos-docker" {
-  count = "${var.docker_count}"
   depends_on = [ "template_file.etcd_cloud_config" ]
-  name = "${var.env}-tsuru-coreos-docker-${count.index}"
+  count = "${var.docker_count}"
+  name = "${element(template_file.etcd_cloud_config.*.vars.telegraf_tag_instance_name, count.index)}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {
@@ -12,7 +12,7 @@ resource "google_compute_instance" "coreos-docker" {
   }
   metadata {
     sshKeys = "core:${file("${var.ssh_key_path}")}"
-    user-data = "${template_file.etcd_cloud_config.rendered}"
+    user_data = "${element(template_file.etcd_cloud_config.*.rendered, count.index)}"
   }
   service_account {
     scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]
@@ -22,10 +22,14 @@ resource "google_compute_instance" "coreos-docker" {
 
 resource "template_file" "etcd_cloud_config" {
   depends_on = [ "template_file.etcd_discovery_url" ]
+  count = "${var.docker_count}"
   filename = "../coreos-config.yaml.tpl"
   vars {
     etcd_discovery_url = "${file("ETCD_CLUSTER_ID")}"
     docker_registry_host = "${replace(google_dns_record_set.docker-registry.name, "/\.$/", ":${var.registry_port}")}"
+    influx_db_host = "${google_compute_instance.influx-grafana.network_interface.0.address}"
+    telegraf_tag_instance_name = "${var.env}-tsuru-coreos-docker-${count.index}"
+    telegraf_tag_type = "coreos-docker"
   }
 }
 

--- a/gce/coreos-docker-servers.tf
+++ b/gce/coreos-docker-servers.tf
@@ -1,7 +1,7 @@
 resource "google_compute_instance" "coreos-docker" {
   depends_on = [ "template_file.etcd_cloud_config" ]
   count = "${var.docker_count}"
-  name = "${element(template_file.etcd_cloud_config.*.vars.telegraf_tag_instance_name, count.index)}"
+  name = "${var.env}-tsuru-coreos-docker-${count.index}"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/coreos-docker-servers.tf
+++ b/gce/coreos-docker-servers.tf
@@ -12,7 +12,7 @@ resource "google_compute_instance" "coreos-docker" {
   }
   metadata {
     sshKeys = "core:${file("${var.ssh_key_path}")}"
-    user_data = "${element(template_file.etcd_cloud_config.*.rendered, count.index)}"
+    user-data = "${element(template_file.etcd_cloud_config.*.rendered, count.index)}"
   }
   service_account {
     scopes = [ "compute-ro", "storage-ro", "userinfo-email" ]

--- a/gce/influx.tf
+++ b/gce/influx.tf
@@ -1,5 +1,5 @@
 resource "google_compute_instance" "influx-grafana" {
-  name = "${var.env}-influx-grafana"
+  name = "${var.env}-tsuru-influx-grafana"
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {


### PR DESCRIPTION
[#106191568 Monitoring dashboard for the trial Tsuru platform](https://www.pivotaltracker.com/story/show/106191568)
# What

We want to build a dashboard to monitor tsuru using grafana for the metrics, including the coreOS searvers
# Context.

We already install grafana in all the servers using ansible, but the coreos servers are not configured with ansible and we don't gather any metrics.

As a solution, we will run telegraf in a container, which is started as a unit by systemd.

In this PR we want:
- Start the image governmentpaas/docker-telegraf using a system using.
- Add additional tags as configuration for telegraf, including:
  - CoreOS instance name, for which we needed to create one template for the user data of each coreos.
  - Private IP
- We also update the name of the influx grafana instance, to keep consistency with the rest of VMs.
# How to test it
1. Start the environment both AWS and GCE
2. go to http://<envname>-grafana.tsuru.paas.alphagov.co.uk:3000 or http://<envname>-grafana.tsuru2.paas.alphagov.co.uk:3000
3. Create a graph and confirm that metrics from CoreOS with the right tags are arriving. (you can import this dashboard if you want: https://gist.github.com/keymon/17d193b1a7b6b61fc6a3)
4. Check if influx-db has the right name and is running.
# Who can review this?

Anyone but @colin, @keymon or @combor 
