### PR TITLE
[#106938990] Node count should be odd for quorum, not even.

### DIFF
--- a/globals.tf
+++ b/globals.tf
@@ -43,7 +43,7 @@ variable "postgres_bucketname" {
 }
 
 variable "docker_count" {
-  description = "Number of docker nodes. For CoreOS this should be at least 3 and even, to make etcd quorums easier"
+  description = "Number of docker nodes. For CoreOS this should be at least 3 and odd, to make etcd quorums easier"
   default = 3
 }
 


### PR DESCRIPTION
**What**

Whilst working on the ticket for adding new clients to Tsuru platform, I noticed that the comment for docker_count was incorrect.

No code changes - just a one-word fix the documentation/comments.

**How to test this PR**

Read the comment inside globals.tf - It will now correctly say that '3' is an odd number, rather than incorrectly saying that it is an even number. There are no code changes with this PR, so no requirement for further tests.

**Who can merge this PR**

Anyone on the core team except me.
