### PR TITLE
[#107379388] Persistent disk for Mongo and Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ the bucket with `-target` to avoid recreating all the other resources:
 ```bash
 # On AWS:
 terraform apply -var env=<env-name-prefix> -var force_destroy=true -target=aws_s3_bucket.registry-s3
+terraform taint aws_instance.tsuru-db # Required due to [bug in Terraform detaching EBS Volumes](https://github.com/hashicorp/terraform/issues/2957)
 terraform destroy -var env=<env-name-prefix> -var force_destroy=true
 # On GCE:
 terraform apply -var env=<env-name-prefix> -var force_destroy=true -target=google_storage_bucket.registry-gcs

--- a/aws/mongo-redis.tf
+++ b/aws/mongo-redis.tf
@@ -1,3 +1,11 @@
+resource "aws_ebs_volume" "tsuru-db" {
+    availability_zone = "${element(aws_subnet.private.*.availability_zone, 0)}"
+    size = 40
+    tags {
+        Name = "tsuru-db"
+    }
+}
+
 resource "aws_instance" "tsuru-db" {
   ami = "${lookup(var.ubuntu_amis, var.region)}"
   instance_type = "t2.medium"
@@ -11,6 +19,13 @@ resource "aws_instance" "tsuru-db" {
   tags = {
     Name = "${var.env}-tsuru-db"
   }
+  user_data = "${file("user-data.tsuru-db")}"
+}
+
+resource "aws_volume_attachment" "ebs_att" {
+  device_name = "/dev/xvdh"
+  volume_id = "${aws_ebs_volume.tsuru-db.id}"
+  instance_id = "${aws_instance.tsuru-db.id}"
 }
 
 resource "aws_security_group" "mongodb" {

--- a/aws/user-data.tsuru-db
+++ b/aws/user-data.tsuru-db
@@ -1,0 +1,47 @@
+#cloud-config
+
+# set up mount points
+# 'mounts' contains a list of lists
+#  the inner list are entries for an /etc/fstab line
+#  ie : [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno ]
+#
+# default:
+# mounts:
+#  - [ ephemeral0, /mnt ]
+#  - [ swap, none, swap, sw, 0, 0 ]
+#
+# in order to remove a previously listed mount (ie, one from defaults)
+# list only the fs_spec.  For example, to override the default, of
+# mounting swap:
+# - [ swap ]
+# or
+# - [ swap, null ]
+#
+# - if a device does not exist at the time, an entry will still be
+#   written to /etc/fstab.
+# - '/dev' can be ommitted for device names that begin with: xvd, sd, hd, vd
+# - if an entry does not have all 6 fields, they will be filled in
+#   with values from 'mount_default_fields' below.
+#
+# Note, that you should set 'nobootwait' (see man fstab) for volumes that may
+# not be attached at instance boot (or reboot)
+#
+
+# On first boot - if xvdh diesn't have an ext4 filesystem, then we'll make one.
+bootcmd:
+  - blkid /dev/xvdh | grep ext4 || mkfs -t ext4 /dev/xvdh
+
+mounts:
+ - [ xvdh, /opt/data, "auto", "defaults,nobootwait", "0", "0" ]
+
+# mount_default_fields
+# These values are used to fill in any entries in 'mounts' that are not
+# complete.  This must be an array, and must have 7 fields.
+mount_default_fields: [ None, None, "auto", "defaults,nobootwait", "0", "2" ]
+
+# swap can also be set up by the 'mounts' module
+# default is to not create any swap files, because 'size' is set to 0
+#swap:
+#   filename: /swap.img
+#   size: "auto" or size in bytes
+#   maxsize: size in bytes


### PR DESCRIPTION
**What**

We wish to have a persistent disk used for data storage on MongoDB and Redis roles. They both
co-exist on the same tsuru-db host.
This PR adds an ELB volume configured by Terraform and attaches it to the tsuru-db instance as /opt/data

**How this PR should be reviewed**

This PR should reviewed in the following context:
- I need a persistent disk attached to my tsuru-db instance
- I need the persitent disk to be formatted (if it hasn't already been done) and mounted as /opt/data
- I need to workaround a bug in terraform when the instance is destroyed (Readme update)

**How to test this PR**
- Deploy tsuru to aws using terraform and ansible as normal.
- Confirm that /opt/data contains a filesystem (lost+found dir present) and that redis and mongo data directories are present on the disk
- Terminate the tsuru-db insance using the EC2 console
- Reprovision the tsuru-db intance using terraform+ansible as normal - it should be recreated with all of the previous data kept intact.
- Destroy the tsuru environment you just created by following the steps in the README.md

**Who should review this PR**
- Anyone in the core team except @timmow who I paired with :-p

**Notes**

The workaround for terraform destroy is required due to a bug in Terraform.
